### PR TITLE
Add Telegram UX and security config improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -585,6 +585,14 @@ pulumi config set telegramUserId "123456789"  # Your numeric user ID
 pulumi up
 ```
 
+**Config applied by Ansible:**
+```
+channels.telegram.tokenFile: ~/.openclaw/.telegram-bot-token  (token stored in file, not in openclaw.json)
+channels.telegram.streamMode: partial    (draft message streaming for incremental output)
+channels.telegram.configWrites: false    (prevents bot from modifying its own config via Telegram)
+channels.telegram.chunkMode: newline     (splits long messages on paragraph boundaries)
+```
+
 ### Getting Telegram IDs
 
 Use `./scripts/get-telegram-id.sh` to discover user IDs and group IDs. The script briefly pauses the gateway (~10s), polls the Telegram API for a message you send, displays the IDs, and restarts the gateway.
@@ -598,7 +606,6 @@ Use `./scripts/get-telegram-id.sh` to discover user IDs and group IDs. The scrip
 ```
 
 Alternatively, message **@userinfobot** on Telegram to get a user ID manually.
-
 ### Scheduled Tasks
 
 When Telegram is configured, these default cron jobs are created for the main agent:

--- a/ansible/roles/telegram/tasks/channel.yml
+++ b/ansible/roles/telegram/tasks/channel.yml
@@ -1,8 +1,8 @@
 ---
-- name: Write Telegram bot token to temp file
+- name: Write Telegram bot token to dedicated file
   ansible.builtin.copy:
     content: "{{ telegram_bot_token }}"
-    dest: /tmp/ansible-telegram-bot-token
+    dest: "{{ ansible_env.HOME }}/.openclaw/.telegram-bot-token"
     mode: "0600"
   no_log: true
   changed_when: false
@@ -11,15 +11,15 @@
   ansible.builtin.shell: |
     set -euo pipefail
     export XDG_RUNTIME_DIR=/run/user/1000
-    BOT_TOKEN=$(cat /tmp/ansible-telegram-bot-token)
-    DESIRED_HASH=$(echo -n "$BOT_TOKEN" | sha256sum | cut -d' ' -f1)
-    CURRENT=$(openclaw config get channels.telegram.botToken 2>/dev/null) || CURRENT=""
-    CURRENT_HASH=$(echo -n "$CURRENT" | sha256sum | cut -d' ' -f1)
     CHANGED=""
-    if [ "$CURRENT_HASH" != "$DESIRED_HASH" ]; then
-        openclaw config set channels.telegram.botToken "$BOT_TOKEN"
+    DESIRED_TOKEN_FILE="{{ ansible_env.HOME }}/.openclaw/.telegram-bot-token"
+    CURRENT_TOKEN_FILE=$(openclaw config get channels.telegram.tokenFile 2>/dev/null) || CURRENT_TOKEN_FILE=""
+    if [ "$CURRENT_TOKEN_FILE" != "$DESIRED_TOKEN_FILE" ]; then
+        openclaw config set channels.telegram.tokenFile "$DESIRED_TOKEN_FILE"
         CHANGED="yes"
     fi
+    # Remove inline botToken if present (superseded by tokenFile)
+    openclaw config unset channels.telegram.botToken 2>/dev/null || true
     ENABLED=$(openclaw config get channels.telegram.enabled 2>/dev/null) || ENABLED=""
     if [ "$ENABLED" != "true" ]; then
         openclaw config set channels.telegram.enabled true
@@ -43,6 +43,27 @@
     CURRENT_DM=$(openclaw config get channels.telegram.dmPolicy 2>/dev/null) || CURRENT_DM=""
     if [ "$CURRENT_DM" != "allowlist" ]; then
         openclaw config set channels.telegram.dmPolicy "allowlist"
+        CHANGED="yes"
+    fi
+
+    # Stream mode: partial for draft message streaming
+    CURRENT_SM=$(openclaw config get channels.telegram.streamMode 2>/dev/null) || CURRENT_SM=""
+    if [ "$CURRENT_SM" != "partial" ]; then
+        openclaw config set channels.telegram.streamMode "partial"
+        CHANGED="yes"
+    fi
+
+    # Disable config writes via Telegram for security
+    CURRENT_CW=$(openclaw config get channels.telegram.configWrites 2>/dev/null) || CURRENT_CW=""
+    if [ "$CURRENT_CW" != "false" ]; then
+        openclaw config set channels.telegram.configWrites false
+        CHANGED="yes"
+    fi
+
+    # Chunk mode: split on paragraph boundaries
+    CURRENT_CM=$(openclaw config get channels.telegram.chunkMode 2>/dev/null) || CURRENT_CM=""
+    if [ "$CURRENT_CM" != "newline" ]; then
+        openclaw config set channels.telegram.chunkMode "newline"
         CHANGED="yes"
     fi
 
@@ -114,9 +135,3 @@
   register: telegram_policies_result
   changed_when: "'UPDATED' in telegram_policies_result.stdout"
   notify: restart openclaw-gateway
-
-- name: Clean up Telegram bot token
-  ansible.builtin.file:
-    path: /tmp/ansible-telegram-bot-token
-    state: absent
-  changed_when: false

--- a/docs/DOCS-REVIEW.md
+++ b/docs/DOCS-REVIEW.md
@@ -28,10 +28,10 @@ Tracking which [OpenClaw docs](https://docs.openclaw.ai) pages have been reviewe
 
 ## Potential Improvements
 
-- **Telegram `streamMode`** — set `channels.telegram.streamMode` to `"partial"` for draft message streaming. Shows incremental output instead of waiting for the full response. (Source: [Gateway Configuration](https://docs.openclaw.ai/gateway/configuration), [Telegram Channel](https://docs.openclaw.ai/channels/telegram))
-- **Telegram `configWrites: false`** — by default, the bot can modify its own config via `/config set` commands in Telegram. Disable with `channels.telegram.configWrites: false` for a security-conscious deployment. (Source: [Telegram Channel](https://docs.openclaw.ai/channels/telegram))
-- **Telegram `chunkMode: "newline"`** — splits long messages on paragraph boundaries instead of hard character limits. Small UX improvement. (Source: [Telegram Channel](https://docs.openclaw.ai/channels/telegram))
-- **Telegram `tokenFile`** — the docs support `channels.telegram.tokenFile` to read the bot token from a file path instead of storing it directly in config. Keeps the token out of `openclaw.json`. (Source: [Telegram Channel](https://docs.openclaw.ai/channels/telegram))
+- ~~**Telegram `streamMode`**~~ — **Applied.** Set `channels.telegram.streamMode` to `"partial"` for draft message streaming.
+- ~~**Telegram `configWrites: false`**~~ — **Applied.** Disabled config writes via Telegram for security.
+- ~~**Telegram `chunkMode: "newline"`**~~ — **Applied.** Splits long messages on paragraph boundaries.
+- ~~**Telegram `tokenFile`**~~ — **Applied.** Bot token read from `~/.openclaw/.telegram-bot-token` file instead of stored in config.
 - **Telegram privacy mode** — by default, Telegram bots only see @mentions and `/commands` in groups (privacy mode enabled). To let the bot see all group messages, disable privacy via BotFather `/setprivacy` or add the bot as a group admin. Only relevant if the bot is used in group chats. (Source: [Telegram Channel](https://docs.openclaw.ai/channels/telegram))
 - ~~**Workspace as private git repo**~~ — **Implemented.** Hourly auto-sync via systemd timer with Pulumi-generated ED25519 deploy key. See CLAUDE.md "Workspace Git Sync" section.
 


### PR DESCRIPTION
## Summary
- Enable draft message streaming (`streamMode: partial`) for incremental Telegram output
- Disable config writes via Telegram (`configWrites: false`) to prevent bot self-modification
- Split long messages on paragraph boundaries (`chunkMode: newline`) for better readability
- Store bot token in dedicated file via `tokenFile` instead of inline in `openclaw.json`

## Changes
- `ansible/roles/telegram/tasks/channel.yml` — switch from inline `botToken` to `tokenFile`, add `streamMode`/`configWrites`/`chunkMode` settings with idempotent change detection
- `CLAUDE.md` — document new Telegram config settings
- `docs/DOCS-REVIEW.md` — mark 4 potential improvements as applied

## Test plan
- [ ] Run `./scripts/provision.sh --tags telegram` against a test server
- [ ] Verify `openclaw config get channels.telegram.tokenFile` returns the file path
- [ ] Verify `openclaw config get channels.telegram.streamMode` returns `partial`
- [ ] Verify `openclaw config get channels.telegram.configWrites` returns `false`
- [ ] Verify `openclaw config get channels.telegram.chunkMode` returns `newline`
- [ ] Send a Telegram message and confirm incremental streaming works
- [ ] Confirm `/config set` commands via Telegram are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)