### PR TITLE
feat(gog): add gogcli as containerized MCP server for Gmail/Google Workspace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ openclaw-infra/
 │       ├── whatsapp/  # WhatsApp channel config (conditional)
 │       ├── obsidian-headless/  # Obsidian Sync daemon per workspace (conditional)
 │       ├── qmd/       # qmd semantic search: install, per-agent watchers
+│       ├── gog/       # gogcli binary, OAuth keyring, gog-mcp Docker image (conditional)
 │       ├── plugins/   # MCP adapter, Codex/Claude Code/Pi/qmd servers, deny rules
 │       ├── sandbox/   # Pull base image, build custom Docker image
 │       └── workspace/ # Deploy key, git sync timer (conditional)
@@ -106,6 +107,7 @@ Use `./scripts/provision.sh --tags <tag>` to run specific roles:
 | `discord` | discord | Configure Discord channel (bot token, guild allowlist) |
 | `obsidian-headless` | obsidian-headless | Update Obsidian Sync daemon config |
 | `qmd` | qmd | Reinstall qmd, update watchers, force reindex |
+| `gog` | gog | Reinstall gogcli, rebuild gog-mcp image, rotate keyring password |
 | `plugins` | plugins | MCP adapter, Codex/Claude Code/Pi containers, GitHub MCP, deny rules |
 | `sandbox` | sandbox | Rebuild custom Docker image |
 | `workspace` | workspace | Deploy key rotation, sync changes |
@@ -259,6 +261,9 @@ Default server type is **CX43** (8 vCPU, 16 GB RAM, ~€9.49/mo). Change with `p
 | Codex auth (`~/.codex/auth.json`) | (Optional) Powers Codex MCP servers for coding assistance | Run `codex login` locally, auto-deployed by provision.sh |
 | Obsidian auth token | (Optional) Authenticates with Obsidian Sync API | `ob login` locally, copy from `~/.obsidian-headless/auth_token` |
 | Obsidian vault password | (Optional) E2EE encryption for Obsidian Sync vaults | User-chosen password |
+| `gogAccount` | (Optional) Google account for `gogcli` MCP server (Gmail/Calendar/Drive) | `pulumi config set gogAccount "you@gmail.com"` |
+| `gogKeyringPassword` | (Optional) Encrypts the file-backed `gogcli` credential keyring | User-chosen password |
+| `gogClientSecret` | (Optional) Google OAuth `client_secret.json` for `gogcli` | console.cloud.google.com → APIs & Services → Credentials |
 
 ## Security DO's and DON'Ts
 
@@ -437,6 +442,20 @@ ssh ubuntu@openclaw-vps 'XDG_RUNTIME_DIR=/run/user/1000 systemctl --user status 
 
 **Read [docs/INTEGRATIONS.md#obsidian-headless-sync](./docs/INTEGRATIONS.md#obsidian-headless-sync) in full when:** first-time Obsidian setup or diagnosing token expiry.
 
+## Gmail / Calendar / Drive (Optional)
+
+Containerized [`gogcli`](https://github.com/steipete/gogcli) MCP server giving agents access to Gmail, Calendar, Drive, and other Google Workspace services. Container runs on `codex-proxy-net` with credentials bind-mounted read-only and a `gog auth …` allowlist block. Pulumi secrets: `gogAccount`, `gogKeyringPassword`, `gogClientSecret`. **One-time manual auth on the VPS** is required after provisioning (the VPS has no browser).
+
+```bash
+pulumi config set gogAccount "you@gmail.com"
+pulumi config set gogKeyringPassword --secret
+pulumi config set gogClientSecret --secret "$(cat /path/to/client_secret.json)"
+./scripts/provision.sh --tags gog,plugins
+# Then on the VPS: gog auth add you@gmail.com --services gmail,calendar --manual
+```
+
+**Read [docs/INTEGRATIONS.md#gmail--calendar--drive-gogcli](./docs/INTEGRATIONS.md#gmail--calendar--drive-gogcli) in full when:** first-time Google Workspace setup (OAuth client creation, manual auth flow) or re-authentication after token revocation.
+
 ## Multi-Agent Setup (Optional)
 
 By default, a single `main` agent is configured. To add more agents, define `openclaw_agents` in `openclaw.yml` (see `openclaw.yml.example`).
@@ -469,7 +488,7 @@ MCP servers, workspaces, deny rules, and token mappings are generated automatica
 
 ### Role Ordering
 
-`config` -> `agents` -> `telegram` -> `whatsapp` -> `discord` -> `obsidian-headless` -> `qmd` -> `plugins` -> `sandbox` -> `workspace`
+`config` -> `agents` -> `telegram` -> `whatsapp` -> `discord` -> `obsidian-headless` -> `qmd` -> `gog` -> `plugins` -> `sandbox` -> `workspace`
 
 Telegram must run immediately after agents (prevents message misrouting). Plugins after qmd (qmd binary needed for MCP registration).
 
@@ -534,7 +553,7 @@ Each agent has a **qmd** instance providing local hybrid search (BM25 + vector +
 - `memory` — memory directory (`.md` files only)
 - `extracted-content` — text extracted from PDFs, images, `.docx`, `.xlsx`
 
-**Tool count:** `N_agents × Σ(tools_per_server_type)`. Per agent: github: 26, codex: 2, claude-code: 2, pi: 2, qmd: 6. Check `openclaw_mcp_server_types` in `group_vars/all.yml`.
+**Tool count:** `N_agents × Σ(tools_per_server_type)`. Per agent: github: 26, codex: 2, claude-code: 2, pi: 2, qmd: 6, gog: 1. Check `openclaw_mcp_server_types` in `group_vars/all.yml`.
 
 **Operations:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Self-hosted [OpenClaw](https://openclaw.ai) gateway on a Hetzner VPS with zero-t
 - **Secure**: Hetzner firewall + UFW + Tailscale-only access + device pairing
 - **Simple**: Pulumi IaC, single command deploy, systemd user service
 - **Telegram**: Optional scheduled tasks (configurable cron jobs)
+- **Google Workspace**: Optional Gmail/Calendar/Drive access via containerized gogcli MCP server
 - **Workspace sync**: Optional hourly git backup of the agent's workspace to GitHub
 
 ## Prerequisites
@@ -81,6 +82,12 @@ pulumi config set telegramUserId "YOUR_ID"     # ./scripts/get-telegram-id.sh or
 
 # Optional: hourly workspace backup to a private GitHub repo
 pulumi config set workspaceRepoUrl "git@github.com:YOU/openclaw-workspace.git"
+
+# Optional: Google Workspace access (Gmail/Calendar/Drive) via gogcli
+# Requires a one-time manual auth step on the VPS — see docs/INTEGRATIONS.md
+pulumi config set gogAccount "you@gmail.com"
+pulumi config set gogKeyringPassword --secret
+pulumi config set gogClientSecret --secret "$(cat /path/to/client_secret.json)"
 
 # Deploy
 pulumi up

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -115,6 +115,17 @@ beads_shared_server_enabled: true
 beads_shared_server_port: 3308
 beads_shared_server_memory_max: "2G"
 
+# gogcli (Google Workspace CLI — Gmail, Calendar, Drive, etc.)
+# Containerized MCP server on codex-proxy-net for credential isolation.
+# Set via: pulumi config set gogAccount "you@gmail.com"
+#          pulumi config set gogKeyringPassword --secret
+#          pulumi config set gogClientSecret --secret  (OAuth client_secret.json content)
+gogcli_version: "0.12.0"
+gog_mcp_docker_image: "gog-mcp:latest"
+gog_mcp_memory_limit: "512m"
+# Allowlist of gog top-level commands (blocks 'auth' manipulation via MCP tool)
+gog_enable_commands: "gmail,calendar,drive,contacts,sheets,docs,slides,forms,tasks,chat,people,classroom,groups,keep,time"
+
 # Force sandbox image rebuild (override with -e force_sandbox_rebuild=true)
 force_sandbox_rebuild: false
 
@@ -126,6 +137,9 @@ force_claude_code_rebuild: false
 
 # Force Pi MCP Docker image rebuild (override with -e force_pi_mcp_rebuild=true)
 force_pi_mcp_rebuild: false
+
+# Force gog MCP Docker image rebuild (override with -e force_gog_mcp_rebuild=true)
+force_gog_mcp_rebuild: false
 
 # Force plugin reinstall (override with -e force_plugin_reinstall=true)
 force_plugin_reinstall: false
@@ -231,6 +245,8 @@ openclaw_mcp_server_types:
     name_prefix: "qmd"
   - type: "node-exec"
     name_prefix: "mac"
+  - type: "gog"
+    name_prefix: "gog"
 
 # Claude Code plugins for MCP containers
 claude_code_plugins:

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -170,7 +170,11 @@
       when: obsidian_headless_enabled | default(false) | bool
     # qmd after obsidian-headless — needs workspace dirs from agents role, before plugins registers MCP servers.
     - { role: qmd,       tags: [qmd],       when: openclaw_mcp_adapter is defined }
-    # plugins after qmd — qmd binary must exist for MCP server registration + deny rules need agents.
+    # gog after qmd — builds gog-mcp Docker image; plugins role registers the MCP server.
+    - role: gog
+      tags: [gog]
+      when: gog_account is defined and gog_account | length > 0
+    # plugins after gog — qmd/gog binaries must exist for MCP server registration + deny rules need agents.
     - { role: plugins,   tags: [plugins],   when: openclaw_mcp_adapter is defined }
     - { role: sandbox,   tags: [sandbox] }
     - role: workspace
@@ -273,19 +277,19 @@
         scope: user
       environment:
         XDG_RUNTIME_DIR: "/run/user/1000"
-      tags: [docker, config, openclaw, sandbox, agents, plugins, qmd, whatsapp, discord]
+      tags: [docker, config, openclaw, sandbox, agents, plugins, qmd, gog, whatsapp, discord]
 
     - name: Wait for gateway to stabilize
       ansible.builtin.pause:
         seconds: 5
-      tags: [docker, config, openclaw, sandbox, agents, plugins, qmd, whatsapp, discord]
+      tags: [docker, config, openclaw, sandbox, agents, plugins, qmd, gog, whatsapp, discord]
 
     - name: Verify gateway is active
       ansible.builtin.command: systemctl --user is-active openclaw-gateway
       environment:
         XDG_RUNTIME_DIR: "/run/user/1000"
       changed_when: false
-      tags: [docker, config, openclaw, sandbox, agents, plugins, qmd, whatsapp, discord]
+      tags: [docker, config, openclaw, sandbox, agents, plugins, qmd, gog, whatsapp, discord]
 
     # After a gateway upgrade, security changes may invalidate device tokens.
     # Devices that reconnect will appear as pending pairing requests.

--- a/ansible/roles/gog/handlers/main.yml
+++ b/ansible/roles/gog/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: restart openclaw-gateway
+  ansible.builtin.systemd:
+    name: openclaw-gateway
+    state: restarted
+    scope: user
+  environment:
+    XDG_RUNTIME_DIR: /run/user/1000

--- a/ansible/roles/gog/tasks/main.yml
+++ b/ansible/roles/gog/tasks/main.yml
@@ -1,0 +1,218 @@
+---
+# Install gogcli binary on VPS host, deploy OAuth credentials, and build
+# the gog-mcp Docker image for containerized MCP access.
+# Skipped entirely when gog_account is not defined (in playbook.yml).
+# Force image rebuild with: -e force_gog_mcp_rebuild=true
+
+# --- Step 1: Install gog binary on host (needed for one-time OAuth setup) ---
+
+- name: Check installed gog version
+  ansible.builtin.shell: |
+    set -euo pipefail
+    if command -v gog &>/dev/null; then
+      gog --version 2>&1 | head -1
+    else
+      echo "not installed"
+    fi
+  args:
+    executable: /bin/bash
+  register: gog_version_check
+  changed_when: false
+
+- name: Download and install gog binary
+  when: "gogcli_version not in gog_version_check.stdout"
+  block:
+    - name: Download gogcli release archive
+      ansible.builtin.get_url:
+        url: "https://github.com/steipete/gogcli/releases/download/v{{ gogcli_version }}/gogcli_{{ gogcli_version }}_linux_amd64.tar.gz"
+        dest: /tmp/gogcli.tar.gz
+        mode: "0644"
+
+    - name: Extract gog binary
+      ansible.builtin.shell: |
+        set -euo pipefail
+        tar -xzf /tmp/gogcli.tar.gz -C /tmp gog
+        install -m 0755 /tmp/gog /usr/local/bin/gog
+      args:
+        executable: /bin/bash
+      become: true
+
+    - name: Clean up download
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      become: true
+      loop:
+        - /tmp/gogcli.tar.gz
+        - /tmp/gog
+      changed_when: false
+
+    - name: Verify gog binary
+      ansible.builtin.command: gog --version
+      changed_when: false
+
+# --- Step 2: Deploy OAuth credentials and configure keyring ---
+
+- name: Ensure gogcli config directory exists
+  ansible.builtin.file:
+    path: /home/ubuntu/.config/gogcli
+    state: directory
+    mode: "0700"
+
+- name: Ensure gogcli keyring directory exists
+  ansible.builtin.file:
+    path: /home/ubuntu/.config/gogcli/keyring
+    state: directory
+    mode: "0700"
+
+- name: Configure keyring backend to file
+  ansible.builtin.copy:
+    content: '{"keyring_backend": "file"}'
+    dest: /home/ubuntu/.config/gogcli/config.json
+    mode: "0600"
+  register: gog_config_changed
+
+- name: Import OAuth client credentials via gog auth credentials
+  when: gog_client_secret is defined and gog_client_secret | length > 0
+  block:
+    - name: Write Google client secret to temp file
+      ansible.builtin.copy:
+        content: "{{ gog_client_secret }}"
+        dest: /tmp/ansible-gog-client-secret.json
+        mode: "0600"
+      no_log: true
+      changed_when: false
+
+    - name: Import credentials into gog
+      ansible.builtin.shell: |
+        set -euo pipefail
+        export GOG_KEYRING_BACKEND=file
+        export GOG_KEYRING_PASSWORD="{{ gog_keyring_password }}"
+        gog auth credentials /tmp/ansible-gog-client-secret.json
+      args:
+        executable: /bin/bash
+      no_log: true
+      register: gog_creds_import
+      changed_when: "'stored' in gog_creds_import.stdout or 'updated' in gog_creds_import.stdout"
+
+  always:
+    - name: Clean up client secret temp file
+      ansible.builtin.file:
+        path: /tmp/ansible-gog-client-secret.json
+        state: absent
+      changed_when: false
+
+# --- Step 3: Build gog-mcp Docker image ---
+
+- name: Check if gog-mcp image exists
+  ansible.builtin.command: "docker image inspect {{ gog_mcp_docker_image }}"
+  register: gog_image_check
+  changed_when: false
+  failed_when: false
+
+- name: Create gog-mcp build directory
+  ansible.builtin.file:
+    path: /home/ubuntu/.openclaw/gog-mcp-build
+    state: directory
+    mode: "0755"
+
+- name: Copy gog binary to build context
+  ansible.builtin.copy:
+    src: /usr/local/bin/gog
+    dest: /home/ubuntu/.openclaw/gog-mcp-build/gog
+    mode: "0755"
+    remote_src: true
+  register: gog_binary_copied
+
+- name: Template gog-mcp Dockerfile
+  ansible.builtin.template:
+    src: Dockerfile.gog-mcp.j2
+    dest: /home/ubuntu/.openclaw/gog-mcp-build/Dockerfile
+    mode: "0644"
+  register: gog_dockerfile_changed
+
+- name: Template gog-mcp server script
+  ansible.builtin.template:
+    src: gog-mcp-server.js.j2
+    dest: /home/ubuntu/.openclaw/gog-mcp-build/gog-mcp-server.js
+    mode: "0644"
+  register: gog_server_changed
+
+- name: Template gog-mcp package.json
+  ansible.builtin.template:
+    src: package.json.j2
+    dest: /home/ubuntu/.openclaw/gog-mcp-build/package.json
+    mode: "0644"
+  register: gog_package_changed
+
+- name: Build gog-mcp Docker image
+  ansible.builtin.shell: |
+    set -euo pipefail
+    docker build -t "{{ gog_mcp_docker_image }}" /home/ubuntu/.openclaw/gog-mcp-build/
+  args:
+    executable: /bin/bash
+  when: >-
+    gog_image_check.rc != 0 or
+    gog_dockerfile_changed.changed or
+    gog_server_changed.changed or
+    gog_package_changed.changed or
+    gog_binary_copied.changed or
+    (force_gog_mcp_rebuild | bool)
+  register: gog_image_build
+  notify: restart openclaw-gateway
+
+- name: Verify gog-mcp image was built
+  ansible.builtin.command: "docker image inspect {{ gog_mcp_docker_image }}"
+  changed_when: false
+
+- name: Smoke test gog-mcp image (version check)
+  ansible.builtin.shell: |
+    docker run --rm "{{ gog_mcp_docker_image }}" sh -c 'gog --version'
+  args:
+    executable: /bin/bash
+  changed_when: false
+  when: gog_image_build is changed
+
+- name: Smoke test gog-mcp image with hardened flags
+  ansible.builtin.shell: |
+    set -euo pipefail
+    docker run --rm \
+      --network=codex-proxy-net \
+      --cap-drop ALL \
+      --security-opt no-new-privileges \
+      --read-only \
+      --tmpfs /tmp:size=64m \
+      --tmpfs /home/node:size=64m,uid=1000,gid=1000 \
+      "{{ gog_mcp_docker_image }}" \
+      sh -c 'test -x /usr/local/bin/gog && test -f /opt/gog-mcp/server.js && echo "hardened-ok"'
+  args:
+    executable: /bin/bash
+  changed_when: false
+  when: gog_image_build is changed
+
+- name: Remove gog-mcp containers after image rebuild
+  ansible.builtin.shell: |
+    set -euo pipefail
+    containers=$(docker ps -aq --filter "label=openclaw-role=gog-mcp")
+    if [ -n "$containers" ]; then
+      echo "$containers" | xargs docker rm -f
+    fi
+  args:
+    executable: /bin/bash
+  register: gog_container_removal
+  changed_when: gog_container_removal.stdout | length > 0
+  when: gog_image_build is changed
+
+- name: Verify no gog-mcp containers remain after cleanup
+  ansible.builtin.shell: |
+    set -euo pipefail
+    count=$(docker ps -aq --filter "label=openclaw-role=gog-mcp" | wc -l)
+    if [ "$count" -ne 0 ]; then
+      echo "ERROR: $count gog-mcp containers still present after removal"
+      docker ps -a --filter "label=openclaw-role=gog-mcp" --format '{{ '{{' }}.ID{{ '}}' }} {{ '{{' }}.Image{{ '}}' }} {{ '{{' }}.Status{{ '}}' }}'
+      exit 1
+    fi
+  args:
+    executable: /bin/bash
+  changed_when: false
+  when: gog_container_removal is changed

--- a/ansible/roles/gog/templates/Dockerfile.gog-mcp.j2
+++ b/ansible/roles/gog/templates/Dockerfile.gog-mcp.j2
@@ -1,0 +1,25 @@
+FROM node:20-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# MCP server dependencies
+WORKDIR /opt/gog-mcp
+COPY package.json ./
+RUN npm install --omit=dev && npm cache clean --force
+
+# gog binary (static Linux amd64, from build context)
+COPY gog /usr/local/bin/gog
+
+# MCP server script
+COPY gog-mcp-server.js ./server.js
+
+# Harden: strip setuid bits
+RUN find / -xdev -perm /4000 -type f -exec chmod u-s {} +
+
+# Prepare gogcli config mount point (bind-mounted at runtime)
+RUN mkdir -p /home/node/.config/gogcli && chown node:node /home/node/.config/gogcli
+
+USER node
+ENTRYPOINT ["node", "/opt/gog-mcp/server.js"]

--- a/ansible/roles/gog/templates/gog-mcp-server.js.j2
+++ b/ansible/roles/gog/templates/gog-mcp-server.js.j2
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// gog MCP server — exposes a single gog_run tool for Google Workspace CLI.
+// Runs inside a hardened Docker container on codex-proxy-net.
+// Managed by Ansible — do not edit on the server.
+
+'use strict';
+
+const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
+const { StdioServerTransport } = require('@modelcontextprotocol/sdk/server/stdio.js');
+const {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} = require('@modelcontextprotocol/sdk/types.js');
+const { execFileSync } = require('child_process');
+
+const TIMEOUT_MS = 120000; // 2 minutes
+const MAX_OUTPUT = 10 * 1024 * 1024; // 10 MB
+
+const server = new Server(
+  { name: 'gog', version: '1.0.0' },
+  { capabilities: { tools: {} } }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: 'run',
+      description:
+        'Run a gog (Google Workspace CLI) command. ' +
+        'Pass the command WITHOUT the leading "gog" prefix. ' +
+        'Examples: "gmail search \'newer_than:7d\' --max 10 --json", ' +
+        '"gmail labels list --json", ' +
+        '"calendar events primary --from 2026-04-01 --to 2026-04-07 --json". ' +
+        'Always use --json for structured output and --no-input to skip prompts.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          command: {
+            type: 'string',
+            description:
+              'Arguments to pass to gog (e.g. "gmail search \'newer_than:7d\' --max 10 --json")',
+          },
+        },
+        required: ['command'],
+      },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  if (request.params.name !== 'run') {
+    return {
+      content: [{ type: 'text', text: `Unknown tool: ${request.params.name}` }],
+      isError: true,
+    };
+  }
+
+  const { command } = request.params.arguments;
+  if (!command || typeof command !== 'string') {
+    return {
+      content: [{ type: 'text', text: 'Missing or invalid "command" argument' }],
+      isError: true,
+    };
+  }
+
+  // Parse command string into args array for execFile (no shell).
+  // Handles simple quoting (single and double quotes).
+  const args = [];
+  let current = '';
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle;
+    } else if (ch === '"' && !inSingle) {
+      inDouble = !inDouble;
+    } else if (ch === ' ' && !inSingle && !inDouble) {
+      if (current.length > 0) {
+        args.push(current);
+        current = '';
+      }
+    } else {
+      current += ch;
+    }
+  }
+  if (current.length > 0) args.push(current);
+
+  try {
+    const stdout = execFileSync('gog', args, {
+      encoding: 'utf-8',
+      timeout: TIMEOUT_MS,
+      maxBuffer: MAX_OUTPUT,
+      env: { ...process.env, GOG_NO_INPUT: '1' },
+    });
+    return { content: [{ type: 'text', text: stdout }] };
+  } catch (err) {
+    const stderr = err.stderr || '';
+    const stdout = err.stdout || '';
+    const output = stderr || stdout || err.message;
+    return {
+      content: [{ type: 'text', text: `gog error (exit ${err.status || '?'}):\n${output}` }],
+      isError: true,
+    };
+  }
+});
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  process.stderr.write(`gog-mcp-server fatal: ${err.message}\n`);
+  process.exit(1);
+});

--- a/ansible/roles/gog/templates/package.json.j2
+++ b/ansible/roles/gog/templates/package.json.j2
@@ -1,0 +1,8 @@
+{
+  "name": "gog-mcp-server",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0"
+  }
+}

--- a/ansible/roles/plugins/tasks/main.yml
+++ b/ansible/roles/plugins/tasks/main.yml
@@ -1170,6 +1170,15 @@
   changed_when: false
   when: claude_setup_token | default('') | length > 0
 
+- name: Write gog keyring password to temp file
+  ansible.builtin.copy:
+    content: "{{ gog_keyring_password }}"
+    dest: "/tmp/ansible-mcp-gog-keyring-pw"
+    mode: "0600"
+  no_log: true
+  changed_when: false
+  when: gog_keyring_password | default('') | length > 0
+
 - name: Build and write plugin config JSON
   ansible.builtin.shell: |
     set -euo pipefail
@@ -1332,6 +1341,52 @@
     {% endfor %}
     fi
 
+    # gog (Google Workspace) servers — containerized with docker run -i
+    # Security: containers have credentials bind-mounted read-only from host.
+    # GOG_ENABLE_COMMANDS blocks auth manipulation. Container on codex-proxy-net
+    # is unreachable from sandbox containers on the default bridge.
+    GOG_IMAGE="{{ gog_mcp_docker_image }}"
+    GOG_MEM="{{ gog_mcp_memory_limit | default('512m') }}"
+    GOG_CONFIG_DIR="/home/ubuntu/.config/gogcli"
+    {% if gog_account | default('') | length > 0 %}
+    if [ -d "$GOG_CONFIG_DIR" ]; then
+    {% for srv in _openclaw_mcp_servers | selectattr('type', 'equalto', 'gog') %}
+        GOG_KEYRING_PW=""
+        if [ -f /tmp/ansible-mcp-gog-keyring-pw ]; then
+            GOG_KEYRING_PW=$(cat /tmp/ansible-mcp-gog-keyring-pw)
+        fi
+        DOCKER_ARGS=$(jq -n \
+            --arg img "$GOG_IMAGE" \
+            --arg agent "{{ srv.agent_id }}" \
+            --arg mem "$GOG_MEM" \
+            --arg config_dir "$GOG_CONFIG_DIR" \
+            --arg account "{{ gog_account }}" \
+            --arg keyring_pw "$GOG_KEYRING_PW" \
+            --arg enable_cmds "{{ gog_enable_commands }}" \
+            '["run","--rm","-i","--init","--network=codex-proxy-net",
+              "--cap-drop","ALL",
+              "--security-opt","no-new-privileges",
+              "--read-only",
+              "--tmpfs","/tmp:size=64m",
+              "--tmpfs","/home/node:size=64m,uid=1000,gid=1000",
+              "--pids-limit","50",
+              "--cpus","1",
+              ("--memory=" + $mem),("--memory-swap=" + $mem),
+              "--label","openclaw-role=gog-mcp",
+              "--label",("openclaw-agent=" + $agent),
+              "--mount",("type=bind,source=" + $config_dir + ",target=/home/node/.config/gogcli,readonly"),
+              "-e",("GOG_ACCOUNT=" + $account),
+              "-e","GOG_KEYRING_BACKEND=file",
+              "-e",("GOG_KEYRING_PASSWORD=" + $keyring_pw),
+              "-e",("GOG_ENABLE_COMMANDS=" + $enable_cmds),
+              "-e","GOG_NO_INPUT=1",
+              $img]')
+        SERVERS=$(echo "$SERVERS" | jq --arg name "{{ srv.name }}" --argjson args "$DOCKER_ARGS" \
+            '. + [{name: $name, transport: "stdio", command: "docker", args: $args}]')
+    {% endfor %}
+    fi
+    {% endif %}
+
     {% if qmd_workspaces | length > 0 %}
     # qmd servers — HTTP daemon mode (decoupled from gateway lifecycle)
     # Port assignment positional over qmd_workspaces list, must match qmd role.
@@ -1469,6 +1524,12 @@
     - name: Clean up Claude setup token temp file
       ansible.builtin.file:
         path: /tmp/ansible-mcp-claude-setup-token
+        state: absent
+      changed_when: false
+
+    - name: Clean up gog keyring password temp file
+      ansible.builtin.file:
+        path: /tmp/ansible-mcp-gog-keyring-pw
         state: absent
       changed_when: false
 

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -203,3 +203,67 @@ ssh ubuntu@openclaw-vps 'XDG_RUNTIME_DIR=/run/user/1000 journalctl --user -u obs
 ### Token Expiry
 
 The Obsidian auth token may expire if the Obsidian Sync subscription lapses or is renewed. Re-run `ob login` locally, update the Pulumi secret, and re-provision with `--tags obsidian-headless`.
+
+## Gmail / Calendar / Drive (gogcli)
+
+Provides Gmail, Calendar, Drive, and other Google Workspace access via [`gogcli`](https://github.com/steipete/gogcli) running as a containerized MCP server on `codex-proxy-net`. The agent gets a single `gog_run` tool (`gog-<id>_run` for non-default agents) that wraps the `gog` CLI; the agent's CLI knowledge comes from its [`gog` skill](https://github.com/openclaw/openclaw/blob/main/skills/gog/SKILL.md), not from the MCP tool. If the three Pulumi secrets below are not set, deployment skips the role and the MCP servers are not registered.
+
+### Setup
+
+1. **Create the OAuth client** in [Google Cloud Console](https://console.cloud.google.com):
+   - Create a project and enable the APIs you want (Gmail API, Google Calendar API, etc.)
+   - **APIs & Services → Credentials → Create Credentials → OAuth client ID**
+   - Application type: **Desktop app**
+   - Download the `client_secret.json`
+
+   See the [gogcli README](https://github.com/steipete/gogcli) for the canonical walkthrough, including which scopes each service needs.
+
+2. **Set Pulumi secrets:**
+   ```bash
+   cd pulumi
+   pulumi config set gogAccount "you@gmail.com"
+   pulumi config set gogKeyringPassword --secret              # choose a strong password — you'll need it again in step 4
+   pulumi config set gogClientSecret --secret "$(cat /path/to/client_secret.json)"
+   ```
+
+3. **Provision:**
+   ```bash
+   ./scripts/provision.sh --tags gog,plugins
+   ```
+   The `gog` role installs the `gogcli` binary, imports the OAuth client into a file-backed keyring at `~/.config/gogcli`, and builds the hardened `gog-mcp:latest` image. The `plugins` role then registers one MCP server per agent.
+
+4. **Authenticate on the VPS** (one-time, manual — the VPS has no browser):
+   ```bash
+   ssh ubuntu@openclaw-vps.<tailnet>.ts.net
+   export GOG_KEYRING_BACKEND=file
+   export GOG_KEYRING_PASSWORD='<the password from step 2>'
+   gog auth add you@gmail.com --services gmail,calendar --manual
+   ```
+   `gog` prints a Google OAuth URL. Open it in a browser on your laptop, sign in, copy the verification code, paste it back into the terminal. The refresh token is stored in the keyring file. Pass whichever `--services` subset you actually need — services not authorized here will fail at the Google API even if `gog_enable_commands` allows the command.
+
+   If you forgot the keyring password, read it back with `pulumi config get gogKeyringPassword --show-secrets`.
+
+### Verify
+
+```bash
+# Per-agent MCP servers are registered
+openclaw config get plugins.entries.openclaw-mcp-adapter.config \
+  | jq '.servers[] | select(.name | startswith("gog"))'
+
+# gog can talk to Google end-to-end (run on the VPS, outside the container)
+ssh ubuntu@openclaw-vps.<tailnet>.ts.net \
+  "GOG_KEYRING_BACKEND=file GOG_KEYRING_PASSWORD='<the password>' gog gmail labels list --json"
+```
+
+Then ask the agent something like "what's in my inbox today?" and confirm it returns Gmail data, not an error.
+
+### Re-authentication
+
+OAuth refresh tokens generally don't expire, but Google revokes them after password changes, manual revocation, or longer inactivity. To re-issue, repeat step 4 — `gog auth add` overwrites the existing keyring entry. To rotate the keyring password itself, update `gogKeyringPassword` in Pulumi, re-provision, then re-run `gog auth add` (the old keyring file becomes unreadable with the new password and must be replaced).
+
+### Operational Notes
+
+- **Multi-agent**: a second agent (e.g., `bob`) automatically gets its own `gog-bob` MCP server via the `openclaw_mcp_server_types × openclaw_agents` cross-product in `playbook.yml`. All agents share the same host-side keyring and OAuth identity.
+- **Allowlist scope**: `gog_enable_commands` in `ansible/group_vars/all.yml` controls which top-level `gog` commands the container will execute. The default list blocks `auth`, `config`, and other meta-commands so an agent cannot manipulate its own credentials through the MCP tool. Edit and re-provision with `--tags gog,plugins` to change the allowlist.
+- **Rebuild image**: `./scripts/provision.sh --tags gog -e force_gog_mcp_rebuild=true` rebuilds `gog-mcp:latest`, runs the smoke tests, and removes any stale containers labelled `openclaw-role=gog-mcp`.
+- **Security model**: container runs with `--cap-drop ALL`, `--read-only`, `no-new-privileges`, `--pids-limit 50`, 512 MB memory cap. The `~/.config/gogcli` directory is bind-mounted **read-only**. The container lives on `codex-proxy-net`, which sandbox containers on the default bridge cannot reach.

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -70,6 +70,9 @@ else
     export PROVISION_DISCORD_BOT_TOKEN=$(pulumi config get discordBotToken 2>/dev/null || echo "")
     export PROVISION_DISCORD_GUILD_ID=$(pulumi config get discordGuildId 2>/dev/null || echo "")
     export PROVISION_DISCORD_USER_ID=$(pulumi config get discordUserId 2>/dev/null || echo "")
+    export PROVISION_GOG_ACCOUNT=$(pulumi config get gogAccount 2>/dev/null || echo "")
+    export PROVISION_GOG_KEYRING_PASSWORD=$(pulumi config get gogKeyringPassword 2>/dev/null || echo "")
+    export PROVISION_GOG_CLIENT_SECRET=$(pulumi config get gogClientSecret 2>/dev/null || echo "")
 
     # Read deploy keys: try structured export first, fall back to individual exports
     # (individual exports exist until first `pulumi up` after migration)
@@ -161,6 +164,7 @@ echo "  grok_search: $([ -n "$(read_env PROVISION_XAI_API_KEY)" ] && echo "confi
 echo "  groq_voice: $([ -n "$(read_env PROVISION_GROQ_API_KEY)" ] && echo "configured" || echo "skipped")"
 echo "  gemini_image: $([ -n "$(read_env PROVISION_GEMINI_API_KEY)" ] && echo "configured" || echo "skipped")"
 echo "  github_mcp (main): $([ -n "$(read_env PROVISION_GITHUB_TOKEN)" ] && echo "configured" || echo "skipped")"
+echo "  gog_gmail: $([ -n "$(read_env PROVISION_GOG_ACCOUNT)" ] && echo "configured" || echo "skipped")"
 echo "  obsidian_headless: $([ -n "$(read_env PROVISION_OBSIDIAN_AUTH_TOKEN)" ] && echo "configured" || echo "skipped")"
 if [ -n "$agent_ids_str" ]; then
     for id in "${agent_ids[@]}"; do
@@ -209,6 +213,9 @@ static = [
     ('discord_bot_token', 'PROVISION_DISCORD_BOT_TOKEN'),
     ('discord_guild_id', 'PROVISION_DISCORD_GUILD_ID'),
     ('discord_user_id', 'PROVISION_DISCORD_USER_ID'),
+    ('gog_account', 'PROVISION_GOG_ACCOUNT'),
+    ('gog_keyring_password', 'PROVISION_GOG_KEYRING_PASSWORD'),
+    ('gog_client_secret', 'PROVISION_GOG_CLIENT_SECRET'),
 ]
 
 with open(sys.argv[1], 'w') as f:


### PR DESCRIPTION
## Summary

- **New `gog` role** (`ansible/roles/gog/`): installs the `gogcli` binary on the host, imports the OAuth client into a file-backed keyring, and builds a hardened `gog-mcp:latest` Docker image with smoke tests
- **MCP server** (`gog-mcp-server.js.j2`, ~120 lines): single `run` tool wrapping `gog` via `execFileSync` (no shell), 120 s timeout, 10 MB output cap, `GOG_NO_INPUT=1` to suppress prompts
- **Containerized on `codex-proxy-net`** for credential isolation — sandbox containers on the default bridge cannot reach it. Hardened with `--cap-drop ALL`, `--read-only`, `no-new-privileges`, `--pids-limit 50`, 512 MB memory cap, and credentials bind-mounted **read-only** from `~/.config/gogcli`
- **Command allowlist** via `GOG_ENABLE_COMMANDS` (gmail, calendar, drive, contacts, sheets, docs, slides, forms, tasks, chat, people, classroom, groups, keep, time) — blocks `gog auth …` manipulation through the MCP tool
- **Auto-wired** by appending one entry to `openclaw_mcp_server_types`. The existing pre_tasks cross-product (`server_types × openclaw_agents`) generates one `gog` server for `main` and one `gog-<id>` server per non-default agent — no per-agent code paths
- **Skipped cleanly** when `gogAccount` is not set: both the `gog` role and the per-agent MCP server registration in the `plugins` role are gated, so deployments without Google Workspace are unaffected

### Design decisions

- **Single `run` tool** instead of one tool per `gog` subcommand: keeps the MCP surface minimal and lets the agent rely on the existing `gog` skill for CLI knowledge
- **Host-side keyring + read-only bind mount** instead of secrets in env vars: the keyring file lives at `~/.config/gogcli` on the host (mode `0700`), mounted read-only into the container; only `GOG_KEYRING_PASSWORD` is passed via env
- **Role ordering** `qmd → gog → plugins`: gog must build its image before `plugins` registers the MCP server, same pattern qmd already uses

### Setup notes

The role imports the OAuth client (`client_secret.json`) but obtaining a refresh token still requires a one-time manual step on the VPS:

```bash
ssh ubuntu@openclaw-vps \
  'GOG_KEYRING_BACKEND=file GOG_KEYRING_PASSWORD=... \
   gog auth add you@gmail.com --services gmail,calendar --manual'
```

`--manual` is required because the VPS has no browser. See the [gogcli README](https://github.com/steipete/gogcli) for OAuth client creation and the full auth flow.

## Changes

- `ansible/roles/gog/` — new role (tasks, handlers, Dockerfile, MCP server template, package.json)
- `ansible/group_vars/all.yml` — `gogcli_version`, `gog_mcp_docker_image`, `gog_mcp_memory_limit`, `gog_enable_commands`, `force_gog_mcp_rebuild`; appends `gog` to `openclaw_mcp_server_types`
- `ansible/playbook.yml` — wires the `gog` role (conditional on `gog_account`) between `qmd` and `plugins`; adds `gog` to the post-task tag list
- `ansible/roles/plugins/tasks/main.yml` — registers per-agent gog MCP servers with hardened `docker run` args, bind-mounts the credentials dir, passes the allowlist
- `scripts/provision.sh` — reads three new Pulumi config keys (`gogAccount`, `gogKeyringPassword`, `gogClientSecret`) and writes them to the secrets file

## Test plan

- [ ] Fresh deploy without `gogAccount` set: `./scripts/provision.sh` skips the `gog` role and `openclaw config get plugins.entries.openclaw-mcp-adapter.config | jq '.servers[].name'` shows no `gog*` entries
- [ ] Set the three Pulumi keys, run `./scripts/provision.sh --tags gog,plugins`: image builds, both smoke tests pass, `gog-mcp:latest` exists
- [ ] Run `gog auth add <account> --services gmail,calendar --manual` on the VPS, complete the OAuth flow in a browser, paste the code back: keyring under `~/.config/gogcli` now contains a refresh token
- [ ] `openclaw config get plugins.entries.openclaw-mcp-adapter.config | jq '.servers[] | select(.name | startswith("gog"))'` shows one entry per agent with the expected `docker run` args
- [ ] Agent successfully calls `gmail labels list --json` end-to-end through the MCP tool
- [ ] Sending an `auth list` command through the MCP tool is rejected by the `GOG_ENABLE_COMMANDS` allowlist
- [ ] Force rebuild: `./scripts/provision.sh --tags gog -e force_gog_mcp_rebuild=true` rebuilds the image and removes stale containers
- [ ] Multi-agent: with `[main, bob]` in `openclaw_agents`, both `gog` and `gog-bob` servers appear with isolated container labels (`openclaw-agent=main` / `openclaw-agent=bob`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)