### PR TITLE
docs: rewrite README for non-devs, add SETUP_PROMPT.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,148 +1,222 @@
 # OpenClaw Infrastructure
 
-Self-hosted [OpenClaw](https://openclaw.ai) gateway on a Hetzner VPS with zero-trust Tailscale networking. No public ports exposed. ~€11.39/month.
+**Your AI assistant shouldn't die when you close your laptop.**
 
-**This is a reference template.** Clone it and adapt for your own deployment — the config values (timezone, model, cron prompts) are working examples you'll customize.
+OpenClaw is an AI agent that runs 24/7 on your own server. It sends you a morning briefing on Telegram. It does research while you sleep. It remembers everything across conversations. It costs less than a Netflix subscription.
 
-## Features
+This repo is everything you need to set that up — from zero to a running AI assistant in about 30 minutes.
 
-- **Cheap**: Hetzner CX43 x86 (8 vCPU, 16 GB) ~€9.49/mo + backups (~€11.39/mo total)
-- **Secure**: Hetzner firewall + UFW + Tailscale-only access + device pairing
-- **Simple**: Pulumi IaC, single command deploy, systemd user service
-- **Telegram**: Optional scheduled tasks (configurable cron jobs)
-- **Workspace sync**: Optional hourly git backup of the agent's workspace to GitHub
+## Why self-host?
 
-## Prerequisites
+Most AI assistants live inside a browser tab. Close it, and they're gone. They don't remember yesterday. They can't reach out to you. They can't work while you're offline.
 
-- Node.js 18+
+A self-hosted OpenClaw is different:
+
+- **Always on.** It runs on a cheap cloud server. Close your laptop, go hiking — it keeps working.
+- **It messages you.** Morning briefings, research results, task updates — delivered to Telegram, WhatsApp, or Discord. You don't have to check on it.
+- **It remembers.** Persistent memory and workspace across every conversation. Context that builds over weeks, not minutes.
+- **It's private.** Your server, your data, your network. No one else can access it — not even the cloud provider can reach the ports.
+- **It's cheap.** ~$12/month for a server with 8 CPUs and 16 GB RAM. No per-message fees beyond your existing Claude subscription.
+
+## What can it actually do?
+
+**Talk to you where you already are**
+Connect Telegram, WhatsApp, or Discord. Ask it questions, give it tasks, get updates — from your phone, your desktop, wherever.
+
+**Work on a schedule**
+Set up recurring tasks: a daily standup summary, a nightly research shift, a weekly planning session. It runs them automatically and delivers the results.
+
+**Run code safely**
+Every session runs in a sandboxed Docker container with a full dev toolchain (Python, Node.js, git, and more). It can write and execute code without risking your server.
+
+**Search the web and your files**
+Web search via Grok, semantic search across its own workspace. It can research topics, read documents, and synthesize findings.
+
+**Control your Mac remotely** (optional)
+Run shell commands on your local machine from the server — useful for automation workflows. Disabled by default, requires explicit opt-in.
+
+**Run multiple agents**
+Need a research agent and a coding agent? Run them in parallel, each with their own workspace and memory.
+
+## What you'll need
+
+No programming experience required, but you should be comfortable with:
+- Typing commands in a terminal
+- Creating accounts on a few services
+- Editing a configuration file
+
+**Accounts to create** (all have free tiers except the server):
+
+| Service | What it's for | Cost |
+|---------|--------------|------|
+| [Hetzner Cloud](https://www.hetzner.com/cloud) | The server that runs your assistant | ~$12/month |
+| [Tailscale](https://tailscale.com/start) | Private networking — makes the server accessible only to your devices | Free |
+| [Anthropic / Claude](https://claude.ai) | The AI that powers OpenClaw | Your existing subscription |
+| [Pulumi](https://www.pulumi.com) | Manages the server setup (so you can recreate it anytime) | Free |
+
+**Optional** (add anytime):
+
+| Service | What it adds |
+|---------|-------------|
+| Telegram | Chat with your assistant from your phone |
+| WhatsApp | Same, via WhatsApp |
+| Discord | Same, via Discord |
+| [xAI / Grok](https://x.ai/api) | Web search capability |
+
+**Software to install on your computer:**
+- [Node.js](https://nodejs.org/) 18 or newer
 - [Pulumi CLI](https://www.pulumi.com/docs/install/)
 - [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/) (`pip install ansible`)
-- [Tailscale](https://tailscale.com/start) installed and connected on your machine
-- Hetzner Cloud API token ([console.hetzner.cloud](https://console.hetzner.cloud/))
-- Tailscale auth key ([login.tailscale.com/admin/settings/keys](https://login.tailscale.com/admin/settings/keys))
-- Tailscale MagicDNS and HTTPS enabled ([login.tailscale.com/admin/dns](https://login.tailscale.com/admin/dns)) — required for Tailscale Serve
-- Claude setup token (run `claude setup-token`)
+- [Tailscale](https://tailscale.com/download)
 
-See [CLAUDE.md](./CLAUDE.md#first-time-setup) for detailed setup instructions.
+## Getting started
 
-### First-Time Tailscale Setup
+### 1. Set up Tailscale (5 min)
 
-If you've never used Tailscale before:
+Tailscale creates a private network between your devices. Your server will only be reachable through this network — no public ports, no exposure to the internet.
 
-1. **Create account**: Go to https://tailscale.com/start
-   - Sign up with GitHub (recommended for infra projects), Google, or email
-   - Free tier supports up to 100 devices
-
-2. **Install on your Mac**:
+1. Create an account at [tailscale.com/start](https://tailscale.com/start) (sign up with GitHub, Google, or email)
+2. Install on your computer:
    ```bash
+   # Mac
    brew install --cask tailscale
-   ```
-   - Open Tailscale from Applications
-   - Click "Allow" for System Extension and VPN Configuration prompts
-   - Click menu bar icon → Log in → Authorize in browser
+   # Then open Tailscale from Applications and log in
 
-3. **Generate auth key for server**:
-   - Go to https://login.tailscale.com/admin/settings/keys
-   - Click "Generate auth key"
-   - Enable: **Reusable**, **Ephemeral**
+   # Linux — see https://tailscale.com/download/linux
+   ```
+3. Enable MagicDNS and HTTPS in the [admin console](https://login.tailscale.com/admin/dns)
+4. Generate a server auth key at [admin console > Keys](https://login.tailscale.com/admin/settings/keys):
+   - Enable **Reusable** and **Ephemeral**
    - Copy the key (starts with `tskey-auth-...`)
 
-### Telegram Bot Setup
+### 2. Get your tokens (5 min)
 
-To enable optional Telegram notifications:
+- **Hetzner API token**: Create at [console.hetzner.cloud](https://console.hetzner.cloud/) → your project → API Tokens
+- **Claude setup token**: Run `claude setup-token` in your terminal
 
-1. **Create a bot**: Open Telegram, search for **@BotFather**, send `/newbot`
-   - Choose a display name (e.g., "OpenClaw Assistant")
-   - Choose a username (must end in "bot", e.g., `openclaw_assistant_bot`)
-   - Copy the bot token (format: `123456789:ABCdefGHIjklMNOpqrsTUVwxyz`)
-
-2. **Get your user ID** (either method):
-   - Run `./scripts/get-telegram-id.sh` — briefly pauses the gateway, you send a message, it shows your IDs
-   - Or search for **@userinfobot** on Telegram, send `/start`, copy your numeric user ID
-
-3. **Configure**: See [Quick Start](#quick-start) below for the Pulumi commands.
-
-## Quick Start
+### 3. Deploy (10 min)
 
 ```bash
+git clone https://github.com/pandysp/openclaw-infra.git && cd openclaw-infra
 npm install
 cd pulumi
-pulumi login             # Authenticate with Pulumi Cloud
+pulumi login
 pulumi stack init prod
 
-# Required
+# Set your secrets
 pulumi config set hcloud:token --secret       # Hetzner API token
-pulumi config set tailscaleAuthKey --secret    # Tailscale auth key
-pulumi config set claudeSetupToken --secret    # From `claude setup-token`
-
-# Optional: Telegram notifications (daily digests, weekly planning)
-pulumi config set telegramBotToken --secret    # From @BotFather
-pulumi config set telegramUserId "YOUR_ID"     # ./scripts/get-telegram-id.sh or @userinfobot
-
-# Optional: hourly workspace backup to a private GitHub repo
-pulumi config set workspaceRepoUrl "git@github.com:YOU/openclaw-workspace.git"
+pulumi config set tailscaleAuthKey --secret    # Tailscale auth key from step 1
+pulumi config set claudeSetupToken --secret    # Claude setup token from step 2
 
 # Deploy
 pulumi up
+```
 
-# Verify (wait ~5 min for cloud-init)
+Wait about 5 minutes for the server to finish setting up, then verify:
+
+```bash
 cd ..
 ./scripts/verify.sh
 ```
 
-> After verifying, clean up the cloud-init log (contains secrets):
-> `ssh ubuntu@openclaw-vps.<tailnet>.ts.net "sudo shred -u /var/log/cloud-init-openclaw.log"`
+### 4. Connect (2 min)
 
-State and secrets are managed by [Pulumi Cloud](https://app.pulumi.com) — no local passphrase needed.
-
-## Access
-
-Wait ~5 minutes after deployment for cloud-init + Ansible to finish, then open:
+Open the web chat:
 ```
-https://openclaw-vps.<tailnet>.ts.net/chat
+https://openclaw-vps.<your-tailnet>.ts.net/chat
 ```
 
-### First-Time Device Pairing
+On first visit, you'll need to pair your device:
+```bash
+ssh ubuntu@openclaw-vps.<your-tailnet>.ts.net 'openclaw devices list'
+ssh ubuntu@openclaw-vps.<your-tailnet>.ts.net 'openclaw devices approve <request-id>'
+```
 
-OpenClaw requires **device pairing** for all connections — including the server's own CLI. On a fresh install:
+Refresh the browser — you're in.
 
-1. **Use the tokenized URL** to access the web UI without pairing:
+> **Shortcut:** Skip pairing with `cd pulumi && pulumi stack output tailscaleUrlWithToken --show-secrets`
+
+### 5. Add Telegram (optional, 5 min)
+
+1. Open Telegram, search for **@BotFather**, send `/newbot`, follow the prompts
+2. Get your user ID: run `./scripts/get-telegram-id.sh` or message **@userinfobot** on Telegram
+3. Configure:
    ```bash
-   cd pulumi && pulumi stack output tailscaleUrlWithToken --show-secrets
-   ```
-   Open that URL in your browser. This bypasses pairing for initial setup.
-
-2. **Approve devices** that need pairing. The server's CLI (used by Ansible) may show as pending:
-   ```bash
-   ssh ubuntu@openclaw-vps.<tailnet>.ts.net 'openclaw devices list'
-   ssh ubuntu@openclaw-vps.<tailnet>.ts.net 'openclaw devices approve <request-id>'
-   ```
-
-3. **If Ansible failed during first deploy** (cron setup skipped due to pairing), re-run after approving:
-   ```bash
+   cd pulumi
+   pulumi config set telegramBotToken --secret    # From @BotFather
+   pulumi config set telegramUserId "YOUR_ID"     # Your numeric user ID
+   cd ..
    ./scripts/provision.sh --tags telegram
    ```
 
-> No public SSH port is exposed. SSH works over Tailscale only.
+Your assistant will now send you a daily standup at 09:30 and run a night shift at 23:00 (customizable).
 
-See [CLAUDE.md](./CLAUDE.md#device-pairing) for details and [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) for common issues.
-
-## Architecture
+## How it works
 
 ```
-Your Machine ──(Tailscale)──> Hetzner VPS ──> OpenClaw Gateway
-                               Hetzner FW: no inbound
-                               UFW: tailscale0 only
-                               Gateway: localhost:18789 (systemd --user)
-                               Tailscale Serve: HTTPS proxy
+Your phone/laptop ──(Tailscale VPN)──> Hetzner cloud server ──> OpenClaw gateway
+                                        No public ports exposed
+                                        Firewall blocks all inbound traffic
+                                        Only your Tailscale devices can connect
 ```
+
+The server runs OpenClaw as a background service. Tailscale provides encrypted networking. A firewall ensures nothing is accessible from the public internet. Your conversations, memory, and workspace live on the server and are optionally backed up to a private GitHub repo.
+
+| Component | What it does |
+|-----------|-------------|
+| **Hetzner VPS** | Runs everything (~$12/month, 8 CPU, 16 GB RAM) |
+| **Tailscale** | Private encrypted network between your devices and the server |
+| **OpenClaw** | The AI gateway — manages sessions, memory, tools, and messaging |
+| **Docker** | Sandboxes every AI session for safety |
+| **Pulumi** | Infrastructure as code — reproducible setup you can recreate anytime |
+| **Ansible** | Configures the server (installs software, sets up services) |
+
+## Day-to-day operations
+
+```bash
+# Check health
+openclaw health
+openclaw doctor
+
+# Update OpenClaw on the server
+./scripts/provision.sh --tags openclaw
+
+# Change settings (model, tools, sandbox config)
+# Edit ansible/group_vars/all.yml, then:
+./scripts/provision.sh --tags config
+
+# Update scheduled tasks
+# Edit ansible/group_vars/openclaw.yml, then:
+./scripts/provision.sh --tags telegram
+
+# Tear everything down
+cd pulumi && pulumi destroy
+```
+
+## Going further
+
+Once you're running, you can:
+
+- **Add WhatsApp or Discord** — see [docs/INTEGRATIONS.md](./docs/INTEGRATIONS.md)
+- **Enable web search** — add an xAI API key (`pulumi config set xaiApiKey --secret`)
+- **Back up the workspace to GitHub** — run `./scripts/setup-workspace.sh`
+- **Run multiple agents** — define them in `ansible/group_vars/openclaw.yml`
+- **Control your Mac remotely** — see [docs/NODE-EXEC.md](./docs/NODE-EXEC.md)
+- **Add semantic search** over the workspace — see the qmd section in [CLAUDE.md](./CLAUDE.md)
+- **Sync with Obsidian** — see [docs/INTEGRATIONS.md](./docs/INTEGRATIONS.md#obsidian-headless-sync)
 
 ## Documentation
 
-- [CLAUDE.md](./CLAUDE.md) — Setup, operations, security, and troubleshooting
-- [docs/SECURITY.md](./docs/SECURITY.md) — Threat model and mitigations
-- [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) — Common issues
-- [docs/BROWSER-CONTROL-PLANNING.md](./docs/BROWSER-CONTROL-PLANNING.md) — Future browser automation approaches
+| Document | When to read it |
+|----------|----------------|
+| [CLAUDE.md](./CLAUDE.md) | Detailed setup, all config options, operations reference |
+| [docs/INTEGRATIONS.md](./docs/INTEGRATIONS.md) | Telegram, WhatsApp, Discord, Obsidian setup |
+| [docs/SECURITY.md](./docs/SECURITY.md) | Threat model and security architecture |
+| [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) | Something not working? Start here |
+
+## Contributing
+
+This is a reference implementation — fork it and make it yours. If you find bugs or have improvements, PRs and issues are welcome.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,222 +1,143 @@
 # OpenClaw Infrastructure
 
-**Your AI assistant shouldn't die when you close your laptop.**
+Deploy [OpenClaw](https://openclaw.ai) on your own server.
 
-OpenClaw is an AI agent that runs 24/7 on your own server. It sends you a morning briefing on Telegram. It does research while you sleep. It remembers everything across conversations. It costs less than a Netflix subscription.
+## Why this setup?
 
-This repo is everything you need to set that up — from zero to a running AI assistant in about 30 minutes.
+You already know what OpenClaw can do. This repo gives you a secure, always-on place to run it.
 
-## Why self-host?
+- **Security first.** Zero public ports. Tailscale zero-trust networking. Firewall blocks all inbound traffic. Only your devices can reach the server.
+- **Always on.** Runs on a VPS that doesn't sleep, travel, or lose WiFi. Your assistant keeps working whether your laptop is open or not.
+- **Your data stays yours.** Conversations, memory, and workspace live on a server you control. Not on someone else's platform.
+- **Reproducible.** Everything is infrastructure as code. Destroy it and recreate it in 30 minutes. Nothing is hand-configured.
+- **Cheap.** ~€11/month for a dedicated server with 8 CPUs and 16 GB RAM.
 
-Most AI assistants live inside a browser tab. Close it, and they're gone. They don't remember yesterday. They can't reach out to you. They can't work while you're offline.
+## Before you start
 
-A self-hosted OpenClaw is different:
+**What it costs:**
 
-- **Always on.** It runs on a cheap cloud server. Close your laptop, go hiking — it keeps working.
-- **It messages you.** Morning briefings, research results, task updates — delivered to Telegram, WhatsApp, or Discord. You don't have to check on it.
-- **It remembers.** Persistent memory and workspace across every conversation. Context that builds over weeks, not minutes.
-- **It's private.** Your server, your data, your network. No one else can access it — not even the cloud provider can reach the ports.
-- **It's cheap.** ~$12/month for a server with 8 CPUs and 16 GB RAM. No per-message fees beyond your existing Claude subscription.
+| Service | Cost |
+|---------|------|
+| Claude Pro subscription (or higher) | ~$20/month |
+| Hetzner VPS (8 vCPU, 16 GB RAM) | ~€11/month |
+| Tailscale | Free |
+| Optional API keys (web search, etc.) | Most have free tiers |
 
-## What can it actually do?
+**What you need:** A computer, an internet connection, a credit card, and about 30 minutes.
 
-**Talk to you where you already are**
-Connect Telegram, WhatsApp, or Discord. Ask it questions, give it tasks, get updates — from your phone, your desktop, wherever.
+## Where to run OpenClaw
 
-**Work on a schedule**
-Set up recurring tasks: a daily standup summary, a nightly research shift, a weekly planning session. It runs them automatically and delivers the results.
+This repo deploys to a VPS, but that's not the only option. Pick what fits your situation:
 
-**Run code safely**
-Every session runs in a sandboxed Docker container with a full dev toolchain (Python, Node.js, git, and more). It can write and execute code without risking your server.
+| | Your Mac/PC | Mac Mini / home server | VPS (this repo) |
+|---|---|---|---|
+| Always on? | No — sleeps when you close the lid | Yes, if you keep it running | Yes |
+| Local hardware access? | Yes — camera, browser, local files | Yes | No (can add a Mac node later) |
+| Monthly cost | Free | One-time ~€700+ | ~€11/month |
+| Security | Only as secure as your network | Same | Zero public ports, Tailscale-only |
+| Setup complexity | Easiest | Medium | Handled by a coding agent |
 
-**Search the web and your files**
-Web search via Grok, semantic search across its own workspace. It can research topics, read documents, and synthesize findings.
+## What you get
 
-**Control your Mac remotely** (optional)
-Run shell commands on your local machine from the server — useful for automation workflows. Disabled by default, requires explicit opt-in.
+**Included:**
+- Hetzner VPS provisioned and configured automatically
+- Tailscale zero-trust networking (no public ports)
+- OpenClaw gateway running as a system service
+- Sandboxed sessions in Docker with a full dev toolchain
+- Web chat interface accessible from any device on your Tailscale network
 
-**Run multiple agents**
-Need a research agent and a coding agent? Run them in parallel, each with their own workspace and memory.
-
-## What you'll need
-
-No programming experience required, but you should be comfortable with:
-- Typing commands in a terminal
-- Creating accounts on a few services
-- Editing a configuration file
-
-**Accounts to create** (all have free tiers except the server):
-
-| Service | What it's for | Cost |
-|---------|--------------|------|
-| [Hetzner Cloud](https://www.hetzner.com/cloud) | The server that runs your assistant | ~$12/month |
-| [Tailscale](https://tailscale.com/start) | Private networking — makes the server accessible only to your devices | Free |
-| [Anthropic / Claude](https://claude.ai) | The AI that powers OpenClaw | Your existing subscription |
-| [Pulumi](https://www.pulumi.com) | Manages the server setup (so you can recreate it anytime) | Free |
-
-**Optional** (add anytime):
-
-| Service | What it adds |
-|---------|-------------|
-| Telegram | Chat with your assistant from your phone |
-| WhatsApp | Same, via WhatsApp |
-| Discord | Same, via Discord |
-| [xAI / Grok](https://x.ai/api) | Web search capability |
-
-**Software to install on your computer:**
-- [Node.js](https://nodejs.org/) 18 or newer
-- [Pulumi CLI](https://www.pulumi.com/docs/install/)
-- [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/) (`pip install ansible`)
-- [Tailscale](https://tailscale.com/download)
+**Optional features** (the coding agent will ask if you want these):
+- **Telegram** — chat with your assistant from your phone, scheduled daily briefings
+- **WhatsApp** — same, via WhatsApp
+- **Discord** — same, via Discord (with per-channel session isolation)
+- **Web search** — research capability via Grok (xAI)
+- **Semantic search** — search across the assistant's own workspace and documents
+- **Workspace backup** — hourly git sync of the workspace to a private GitHub repo
+- **Multiple agents** — run several agents in parallel, each with their own workspace
+- **Mac remote control** — let the assistant run commands on your local Mac
+- **Obsidian sync** — two-way sync between agent workspace and Obsidian for mobile access
+- **GitHub OAuth** — seamless git authentication inside workspaces
+- **Custom domain** — wildcard TLS via Cloudflare for nicer URLs
 
 ## Getting started
 
-### 1. Set up Tailscale (5 min)
+You don't need to understand this repo or type infrastructure commands yourself. A coding agent will read the repo and guide you through everything — creating accounts, installing tools, deploying the server, and configuring features.
 
-Tailscale creates a private network between your devices. Your server will only be reachable through this network — no public ports, no exposure to the internet.
+### 1. Set up your coding agent
 
-1. Create an account at [tailscale.com/start](https://tailscale.com/start) (sign up with GitHub, Google, or email)
-2. Install on your computer:
-   ```bash
-   # Mac
-   brew install --cask tailscale
-   # Then open Tailscale from Applications and log in
+If you don't have a coding agent yet, pick one and install it:
 
-   # Linux — see https://tailscale.com/download/linux
-   ```
-3. Enable MagicDNS and HTTPS in the [admin console](https://login.tailscale.com/admin/dns)
-4. Generate a server auth key at [admin console > Keys](https://login.tailscale.com/admin/settings/keys):
-   - Enable **Reusable** and **Ephemeral**
-   - Copy the key (starts with `tskey-auth-...`)
+**Option A — Claude Code** (recommended)
+1. Subscribe to [Claude Pro](https://claude.ai/pro) ($20/month) or higher
+2. Install Claude Code:
+   - **Mac/Linux:** Open Terminal, run: `npm install -g @anthropic-ai/claude-code`
+   - **Windows:** First install [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) by opening PowerShell as Administrator and running `wsl --install`, then restart your computer. Open the Ubuntu terminal that appears and run: `npm install -g @anthropic-ai/claude-code`
 
-### 2. Get your tokens (5 min)
+**Option B — Codex**
+1. Subscribe to [ChatGPT Pro](https://openai.com/chatgpt/pricing/)
+2. Install: `npm install -g @openai/codex`
 
-- **Hetzner API token**: Create at [console.hetzner.cloud](https://console.hetzner.cloud/) → your project → API Tokens
-- **Claude setup token**: Run `claude setup-token` in your terminal
+**Option C — Cursor**
+1. Download [Cursor](https://cursor.com) (free tier available)
+2. Install and open it
 
-### 3. Deploy (10 min)
+> **Note:** If you don't have Node.js installed (needed for Options A and B), download it from [nodejs.org](https://nodejs.org/) first. Pick the LTS version.
 
-```bash
-git clone https://github.com/pandysp/openclaw-infra.git && cd openclaw-infra
-npm install
-cd pulumi
-pulumi login
-pulumi stack init prod
+### 2. Clone this repo
 
-# Set your secrets
-pulumi config set hcloud:token --secret       # Hetzner API token
-pulumi config set tailscaleAuthKey --secret    # Tailscale auth key from step 1
-pulumi config set claudeSetupToken --secret    # Claude setup token from step 2
-
-# Deploy
-pulumi up
-```
-
-Wait about 5 minutes for the server to finish setting up, then verify:
+Open your terminal (or Ubuntu terminal on Windows) and run:
 
 ```bash
-cd ..
-./scripts/verify.sh
+git clone https://github.com/pandysp/openclaw-infra.git
+cd openclaw-infra
 ```
 
-### 4. Connect (2 min)
+### 3. Start the coding agent
 
-Open the web chat:
-```
-https://openclaw-vps.<your-tailnet>.ts.net/chat
-```
-
-On first visit, you'll need to pair your device:
-```bash
-ssh ubuntu@openclaw-vps.<your-tailnet>.ts.net 'openclaw devices list'
-ssh ubuntu@openclaw-vps.<your-tailnet>.ts.net 'openclaw devices approve <request-id>'
-```
-
-Refresh the browser — you're in.
-
-> **Shortcut:** Skip pairing with `cd pulumi && pulumi stack output tailscaleUrlWithToken --show-secrets`
-
-### 5. Add Telegram (optional, 5 min)
-
-1. Open Telegram, search for **@BotFather**, send `/newbot`, follow the prompts
-2. Get your user ID: run `./scripts/get-telegram-id.sh` or message **@userinfobot** on Telegram
-3. Configure:
-   ```bash
-   cd pulumi
-   pulumi config set telegramBotToken --secret    # From @BotFather
-   pulumi config set telegramUserId "YOUR_ID"     # Your numeric user ID
-   cd ..
-   ./scripts/provision.sh --tags telegram
-   ```
-
-Your assistant will now send you a daily standup at 09:30 and run a night shift at 23:00 (customizable).
-
-## How it works
-
-```
-Your phone/laptop ──(Tailscale VPN)──> Hetzner cloud server ──> OpenClaw gateway
-                                        No public ports exposed
-                                        Firewall blocks all inbound traffic
-                                        Only your Tailscale devices can connect
-```
-
-The server runs OpenClaw as a background service. Tailscale provides encrypted networking. A firewall ensures nothing is accessible from the public internet. Your conversations, memory, and workspace live on the server and are optionally backed up to a private GitHub repo.
-
-| Component | What it does |
-|-----------|-------------|
-| **Hetzner VPS** | Runs everything (~$12/month, 8 CPU, 16 GB RAM) |
-| **Tailscale** | Private encrypted network between your devices and the server |
-| **OpenClaw** | The AI gateway — manages sessions, memory, tools, and messaging |
-| **Docker** | Sandboxes every AI session for safety |
-| **Pulumi** | Infrastructure as code — reproducible setup you can recreate anytime |
-| **Ansible** | Configures the server (installs software, sets up services) |
-
-## Day-to-day operations
+Launch your coding agent inside the repo directory:
 
 ```bash
-# Check health
-openclaw health
-openclaw doctor
+# Claude Code
+claude
 
-# Update OpenClaw on the server
-./scripts/provision.sh --tags openclaw
+# Codex
+codex
 
-# Change settings (model, tools, sandbox config)
-# Edit ansible/group_vars/all.yml, then:
-./scripts/provision.sh --tags config
-
-# Update scheduled tasks
-# Edit ansible/group_vars/openclaw.yml, then:
-./scripts/provision.sh --tags telegram
-
-# Tear everything down
-cd pulumi && pulumi destroy
+# Cursor — open the folder in the Cursor app
 ```
 
-## Going further
+### 4. Give it the setup prompt
 
-Once you're running, you can:
+Copy and paste the contents of [`SETUP_PROMPT.md`](./SETUP_PROMPT.md) into the coding agent. It contains the exact instructions for the agent to guide you through the full setup.
 
-- **Add WhatsApp or Discord** — see [docs/INTEGRATIONS.md](./docs/INTEGRATIONS.md)
-- **Enable web search** — add an xAI API key (`pulumi config set xaiApiKey --secret`)
-- **Back up the workspace to GitHub** — run `./scripts/setup-workspace.sh`
-- **Run multiple agents** — define them in `ansible/group_vars/openclaw.yml`
-- **Control your Mac remotely** — see [docs/NODE-EXEC.md](./docs/NODE-EXEC.md)
-- **Add semantic search** over the workspace — see the qmd section in [CLAUDE.md](./CLAUDE.md)
-- **Sync with Obsidian** — see [docs/INTEGRATIONS.md](./docs/INTEGRATIONS.md#obsidian-headless-sync)
+The agent will:
+- Check your system and install any missing prerequisites
+- Walk you through creating the necessary accounts (Hetzner, Tailscale)
+- Help you generate API keys and tokens
+- Deploy the server
+- Verify everything is working
+- Ask which optional features you'd like to enable
+- Configure those features for you
+
+### If something goes wrong
+
+Paste the error message into the coding agent and ask it to fix it. These agents are good at diagnosing and recovering from infrastructure issues. If the agent gets stuck, the [troubleshooting guide](./docs/TROUBLESHOOTING.md) covers common problems.
 
 ## Documentation
 
-| Document | When to read it |
-|----------|----------------|
-| [CLAUDE.md](./CLAUDE.md) | Detailed setup, all config options, operations reference |
-| [docs/INTEGRATIONS.md](./docs/INTEGRATIONS.md) | Telegram, WhatsApp, Discord, Obsidian setup |
+These docs are primarily for coding agents, but humans are welcome too:
+
+| Document | What it covers |
+|----------|---------------|
+| [CLAUDE.md](./CLAUDE.md) | Complete setup reference, all config options, operations guide |
+| [SETUP_PROMPT.md](./SETUP_PROMPT.md) | The starter prompt for your coding agent |
+| [docs/INTEGRATIONS.md](./docs/INTEGRATIONS.md) | Telegram, WhatsApp, Discord, Obsidian setup details |
 | [docs/SECURITY.md](./docs/SECURITY.md) | Threat model and security architecture |
-| [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) | Something not working? Start here |
+| [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md) | Common issues and fixes |
 
 ## Contributing
 
-This is a reference implementation — fork it and make it yours. If you find bugs or have improvements, PRs and issues are welcome.
+Issues and pull requests are welcome. This is a reference implementation — fork it and make it yours.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,28 @@ You already know what OpenClaw can do. This repo gives you a secure, always-on p
 - **Security first.** Zero public ports. Tailscale zero-trust networking. Firewall blocks all inbound traffic. Only your devices can reach the server.
 - **Always on.** Runs on a VPS that doesn't sleep, travel, or lose WiFi. Your assistant keeps working whether your laptop is open or not.
 - **Your data stays yours.** Conversations, memory, and workspace live on a server you control. Not on someone else's platform.
-- **Reproducible.** Everything is infrastructure as code. Destroy it and recreate it in 30 minutes. Nothing is hand-configured.
+- **Fully automated.** One command creates the server, installs all software, and configures everything. No clicking through dashboards or installing things by hand.
 - **Cheap.** ~€11/month for a dedicated server with 8 CPUs and 16 GB RAM.
+
+## How it works
+
+This repo uses an approach called **Infrastructure as Code**. Instead of manually creating a server through a web interface — choosing the size, the operating system, installing software, configuring services — everything is described in files that a tool reads and executes automatically.
+
+That means:
+
+- **No manual setup.** You don't need to select a server type, configure RAM, set up a firewall, or install any software on the server. It's all defined in the repo and happens automatically.
+- **Reproducible.** If something goes wrong, you can destroy the server and recreate an identical one in 30 minutes. Nothing is lost because nothing was configured by hand.
+- **Versionable.** The entire setup lives in this git repo. Changes are tracked, reversible, and shareable.
+
+The tools that make this work:
+
+| Tool | What it does |
+|------|-------------|
+| **Pulumi** | Creates the cloud server on Hetzner and configures networking. Think of it as a blueprint for your infrastructure. |
+| **Ansible** | Installs and configures everything on the server — Docker, OpenClaw, security settings, integrations. Think of it as a checklist that runs itself. |
+| **Tailscale** | Creates a private encrypted network between your devices and the server. Nothing is exposed to the public internet. |
+
+You don't need to learn any of these tools. The coding agent handles them for you.
 
 ## Before you start
 

--- a/SETUP_PROMPT.md
+++ b/SETUP_PROMPT.md
@@ -1,0 +1,42 @@
+# Setup Prompt
+
+Copy and paste everything below the line into your coding agent (Claude Code, Codex, Cursor, etc.).
+
+---
+
+I want to deploy OpenClaw on a Hetzner VPS using this repo. I'm not a developer — please handle everything for me. Do not ask me to run commands myself; execute them directly. Only ask me when you need me to do something in a browser (like creating an account or copying an API key).
+
+Here's how to proceed:
+
+1. **Check my system.** Verify I have everything needed: Node.js, Pulumi CLI, Ansible, Tailscale, git. If anything is missing, install it for me. If I'm on Windows, verify WSL is set up correctly.
+
+2. **Read the docs.** Read `CLAUDE.md` thoroughly — it's your reference for the full setup. Also read `docs/INTEGRATIONS.md` for optional features.
+
+3. **Walk me through account creation.** I need accounts on:
+   - **Hetzner Cloud** (for the server) — guide me to create an account and generate an API token
+   - **Tailscale** (for private networking) — guide me to create an account, install it on my machine, enable MagicDNS and HTTPS, and generate a reusable auth key
+   - **Claude / Anthropic** — I need a setup token (run `claude setup-token`)
+   - **Pulumi** (for infrastructure management) — guide me to create a free account
+
+   Open the relevant URLs for me when possible. Wait for me to provide each token/key before continuing.
+
+4. **Configure and deploy.** Run `npm install`, set up the Pulumi stack, configure all required secrets, and run `pulumi up`. Wait for the deployment to complete.
+
+5. **Verify.** Run `./scripts/verify.sh` and confirm everything is healthy. Help me pair my first device so I can access the web chat.
+
+6. **Offer optional features.** After the base setup is working, ask me about each optional feature one at a time. Explain what each one does in plain language, and if I want it, set it up for me:
+   - **Telegram** — chat with my assistant from my phone + scheduled daily briefings
+   - **WhatsApp** — chat via WhatsApp
+   - **Discord** — chat via Discord with per-channel sessions
+   - **Web search** — let the assistant search the web (needs an xAI API key)
+   - **Workspace backup** — hourly backup of the workspace to a private GitHub repo
+   - **Multiple agents** — run several assistants in parallel
+   - **Mac remote control** — let the assistant run commands on my Mac
+   - **Obsidian sync** — two-way sync with Obsidian for mobile access
+   - **Semantic search** — search across the assistant's workspace and documents
+
+   For each feature I enable, configure it fully, verify it works, and move on to the next.
+
+7. **Clean up.** After setup, shred the cloud-init log as documented in CLAUDE.md. Run a final health check. Give me a summary of what's running, how to access it, and what the monthly cost will be.
+
+Take your time. Verify each step before moving to the next. If something fails, diagnose and fix it — don't skip ahead.


### PR DESCRIPTION
## Summary

Rewrites the README to be approachable for non-technical users and introduces a coding-agent-guided setup flow.

- **Start with Why** — security, always-on, data sovereignty, full automation, cost
- **"How it works"** section explaining Infrastructure as Code in plain language (no jargon)
- **Deployment decision table** — Mac vs Mac Mini vs VPS with honest tradeoffs
- **Getting started = install a coding agent** — includes WSL for Windows, Claude Code / Codex / Cursor options, Node.js note
- **SETUP_PROMPT.md** — the exact prompt to paste into a coding agent; it guides the full setup hands-free (prereqs, accounts, deploy, verify, optional features one by one)
- **Optional features clearly listed** so coding agents discover them and offer them to the user
- **Cost table up front** — Claude Pro + Hetzner + Tailscale, honest total

## Design decisions

- README is for humans. CLAUDE.md + docs are for coding agents.
- Setup is done BY coding agents, not by humans typing commands.
- No salesy language. Competence speaks for itself.
- Feature catalog stays high-level in README; exhaustive detail lives in CLAUDE.md.

## Follow-up ideas (not in this PR)

- Bootstrap script (OS detection + prereq install) to further reduce friction
- CLAUDE.md restructuring for better agent feature discovery
- Browser automation for account creation steps
