### PR TITLE
chore: upgrade openclaw to 2026.4.15

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -31,7 +31,7 @@ openclaw_custom_models:
           contextWindow: 200000
           maxTokens: 128000
 nodejs_major_version: 25
-openclaw_version: "2026.4.11"
+openclaw_version: "2026.4.15"
 openclaw_heartbeat_interval: "30m"
 openclaw_agent_timeout_seconds: 1500  # 25 minutes per conversation turn (default: 600)
 openclaw_cooldown_failure_window_hours: 1  # reset cooldown error count after 1h (default: 24)


### PR DESCRIPTION
Primary driver: 2026.4.15 ships the fix (#67557) for a SIGUSR1 restart loop on Linux/systemd when plugin auto-enable is the only startup config write. The old loop eventually corrupts manifest.db.

Also includes the Codex gateway crash fix (#67947), unknown-tool stream guard on by default, and Opus 4.7 as the new Anthropic default.