### PR TITLE
fix: three idempotency/UX bugs in provisioning

### DIFF
--- a/ansible/roles/openclaw/tasks/install.yml
+++ b/ansible/roles/openclaw/tasks/install.yml
@@ -71,6 +71,7 @@
         PATH: "/home/ubuntu/.npm-global/bin:{{ ansible_facts['env']['PATH'] }}"
 
     - name: Confirm installed version matches target
+      when: not ansible_check_mode
       ansible.builtin.assert:
         that:
           - (openclaw_post_install_version.stdout | regex_search('[0-9]+\\.[0-9]+\\.[0-9]+') | default('')) == openclaw_version

--- a/ansible/roles/plugins/tasks/main.yml
+++ b/ansible/roles/plugins/tasks/main.yml
@@ -1605,7 +1605,9 @@
 - name: Check current memorySearch state
   ansible.builtin.shell: |
     export XDG_RUNTIME_DIR=/run/user/1000
-    RESULT=$(jq -r '.agents.defaults.memorySearch.enabled // "unset"' /home/ubuntu/.openclaw/openclaw.json 2>/dev/null || echo "unset")
+    # jq's `//` treats `false` as "missing" and returns the RHS; a conditional
+    # lets us distinguish an explicit `false` from an absent key.
+    RESULT=$(jq -r '.agents.defaults.memorySearch.enabled | if . == null then "unset" else tostring end' /home/ubuntu/.openclaw/openclaw.json 2>/dev/null || echo "unset")
     echo "$RESULT"
   args:
     executable: /bin/bash

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -265,8 +265,10 @@ echo "14. Checking scheduled tasks..."
 CRON_LIST=$(ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new "ubuntu@$FULL_HOSTNAME" \
     "openclaw cron list 2>&1" || echo "FAILED")
 
-CRON_COUNT=$(echo "$CRON_LIST" | grep -c "idle\|running" || echo "0")
-if [[ "$CRON_COUNT" -gt 0 ]]; then
+CRON_COUNT=$(echo "$CRON_LIST" | grep -c -E "idle|running" || true)
+if [[ "$CRON_LIST" == "FAILED" ]]; then
+    check_warn "Could not reach server to list cron jobs"
+elif [[ "$CRON_COUNT" -gt 0 ]]; then
     check_pass "$CRON_COUNT scheduled task(s) configured"
     echo "$CRON_LIST" | grep -E "idle|running" | sed 's/^/   /'
 else


### PR DESCRIPTION
1. plugins role always rewrites memorySearch=false on every --tags plugins run, triggering an unnecessary gateway restart. jq's `//` alternative operator treats `false` as "missing" and returns the RHS, so the guard that checks "is memorySearch already disabled" always saw "unset" and always re-disabled. Use an explicit `if . == null` check instead.

2. openclaw role fails loudly in check mode because the post-install version assertion runs even though the npm-install task is skipped (Ansible's `command` module default in check mode). The "Manual intervention required" rescue message made routine dry-runs look catastrophic. Skip the assert when ansible_check_mode is true.

3. verify.sh cron check parsed as a multi-line value (`"0\n0"`) because `grep -c` already prints 0 on no matches but exits non-zero, which triggered the `|| echo "0"` fallback and concatenated both. Switch to `|| true`, use `-E` for portable alternation, and add an explicit branch for SSH-unreachable case.