### PR TITLE
fix(plugins): remove apostrophe from comment breaking YAML parse

### DIFF
--- a/ansible/roles/plugins/tasks/main.yml
+++ b/ansible/roles/plugins/tasks/main.yml
@@ -1605,8 +1605,8 @@
 - name: Check current memorySearch state
   ansible.builtin.shell: |
     export XDG_RUNTIME_DIR=/run/user/1000
-    # jq's `//` treats `false` as "missing" and returns the RHS; a conditional
-    # lets us distinguish an explicit `false` from an absent key.
+    # The jq // operator treats false as "missing" and returns the RHS, so we
+    # use an explicit null check to distinguish false from an absent key.
     RESULT=$(jq -r '.agents.defaults.memorySearch.enabled | if . == null then "unset" else tostring end' /home/ubuntu/.openclaw/openclaw.json 2>/dev/null || echo "unset")
     echo "$RESULT"
   args:


### PR DESCRIPTION
The comment `jq's \`//\`` has an unbalanced apostrophe that Ansible's Jinja2 pre-parser treats as an unclosed quote, causing:

  [ERROR]: Error loading tasks: failed at splitting arguments,
  either an unbalanced jinja2 block or quotes

This blocks every provisioning run on main since PR #15 merged. Rewrite the comment to avoid the apostrophe.

Reproduction: ./scripts/provision.sh --tags openclaw --check --diff
Regression introduced in: 6a3c4d3 (merged via PR #15)