### PR TITLE
Sync AGENTS.md template with upstream + fail loudly when workspace backup is missing

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -83,6 +83,39 @@
       when: openclaw_workspaces is not defined
       tags: [always]
 
+    # Fail loudly if any agent in `openclaw_agents` is missing its workspace<Agent>RepoUrl
+    # in Pulumi config. Without it, the workspace role silently skips the agent, and
+    # everything they write (daily notes, MEMORY.md, custom AGENTS.md) lives only on the
+    # VPS disk with no GitHub backup. To opt out for a specific agent (rare), add it to
+    # `openclaw_workspace_backup_optouts` in group_vars/openclaw.yml.
+    - name: Assert all agents have GitHub workspace backup configured
+      ansible.builtin.assert:
+        that:
+          - _agents_missing_workspace_backup | length == 0
+        fail_msg: |-
+          The following agent(s) are in `openclaw_agents` but have no `workspace<Agent>RepoUrl`
+          set in Pulumi config: {{ _agents_missing_workspace_backup | join(', ') }}
+
+          Their workspaces will live ONLY on the VPS disk — no GitHub backup. Fix:
+
+            cd {{ playbook_dir }}/..
+          {% for aid in _agents_missing_workspace_backup %}
+            ./scripts/setup-workspace.sh {{ aid }}
+          {% endfor %}
+            ./scripts/provision.sh --tags workspace
+
+          To opt out an agent (rare; data loss on VPS failure), add it to
+          `openclaw_workspace_backup_optouts` in group_vars/openclaw.yml.
+      vars:
+        _optouts: "{{ openclaw_workspace_backup_optouts | default([]) }}"
+        _agents_missing_workspace_backup: >-
+          {{ _openclaw_workspaces
+             | rejectattr('agent_id', 'in', _optouts)
+             | selectattr('repo_url', 'eq', '')
+             | map(attribute='agent_id')
+             | list }}
+      tags: [always]
+
     - name: Initialize qmd_workspaces list
       ansible.builtin.set_fact:
         qmd_workspaces: []

--- a/ansible/roles/workspace/files/AGENTS.md.reference
+++ b/ansible/roles/workspace/files/AGENTS.md.reference
@@ -8,14 +8,19 @@ If `BOOTSTRAP.md` exists, that's your birth certificate. Follow it, figure out w
 
 ## Session Startup
 
-Before doing anything else:
+Use runtime-provided startup context first.
 
-1. Read `SOUL.md` — this is who you are
-2. Read `USER.md` — this is who you're helping
-3. Read `memory/YYYY-MM-DD.md` (today + yesterday) for recent context
-4. Read `MEMORY.md` for long-term context
+That context may already include:
 
-Don't ask permission. Just do it.
+- `AGENTS.md`, `SOUL.md`, and `USER.md`
+- recent daily memory such as `memory/YYYY-MM-DD.md`
+- `MEMORY.md` when this is the main session
+
+Do not manually reread startup files unless:
+
+1. The user explicitly asks
+2. The provided context is missing something you need
+3. You need a deeper follow-up read beyond the provided startup context
 
 ## Memory
 
@@ -205,9 +210,6 @@ Skills provide your tools. When you need one, check its `SKILL.md`. Keep local n
 ## 💓 Heartbeats - Be Proactive!
 
 When you receive a heartbeat poll (message matches the configured heartbeat prompt), don't just reply `HEARTBEAT_OK` every time. Use heartbeats productively!
-
-Default heartbeat prompt:
-`Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.`
 
 You are free to edit `HEARTBEAT.md` with a short checklist or reminders. Keep it small to limit token burn.
 


### PR DESCRIPTION
## Summary

Two related changes from auditing the workspace `AGENTS.md` setup against the live OpenClaw source code.

### 1. Sync `AGENTS.md.reference` with upstream template

Match `openclaw/openclaw` `docs/reference/templates/AGENTS.md`:

- **Session Startup**: replace the imperative "read SOUL.md, USER.md, MEMORY.md" steps with the upstream "use runtime-provided context first" phrasing. The bootstrap injection (`src/agents/system-prompt.ts`, `CONTEXT_FILE_ORDER`) already loads those files into the system prompt, so re-reading them every session was wasted tokens and fought the prompt-cache boundary.
- **Heartbeats**: drop the "Default heartbeat prompt:" 3-line block. OpenClaw's `system-prompt.ts:71-76` (`sanitizeContextFileContentForPrompt`) actively strips that exact text from injected context files — so it was wasted bytes that never reached the model.

This file is a docs snapshot only (no Ansible task deploys it). The live agent `AGENTS.md` files in each agent's GitHub workspace repo are the source of truth and were updated separately.

### 2. Fail loudly when an agent has no GitHub workspace backup

Adds a `pre_task` assert that fires when any agent in `openclaw_agents` has an empty `repo_url` in `_openclaw_workspaces` (i.e., no `workspace<Agent>RepoUrl` set in Pulumi).

**Why this matters:** the workspace role's `when:` guard silently skips agents whose `repo_url` is empty. Found two agents (cama, franca) in this state during the audit — their daily notes, `MEMORY.md`, and custom `AGENTS.md` were living only on VPS disk with no backup. Provisioning never warned; the only signal was a `workspace_sync (cama): skipped` line in `provision.sh`'s summary that read like an intentional choice.

The assert lists the missing agent IDs and prints copy-pastable `./scripts/setup-workspace.sh <id>` commands. Escape hatch: `openclaw_workspace_backup_optouts: [<agent>]` for the rare case where backup is intentionally off. Default strict.

## Test plan

- [ ] `ansible-playbook playbook.yml --syntax-check` passes (verified locally)
- [ ] With cama+franca still missing config: `./scripts/provision.sh --tags always` should fail at the new assert with the expected message
- [ ] After running `./scripts/setup-workspace.sh cama && ./scripts/setup-workspace.sh franca`: provision should pass the assert
- [ ] Add `cama` to `openclaw_workspace_backup_optouts`: assert should pass even without `repo_url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)