### PR TITLE
ansible: fix two fresh-install regressions on 2026.6.1 (docker reconnect + onboard health probe)

### DIFF
--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -38,11 +38,27 @@
 - name: Reset SSH connection to pick up new docker group
   ansible.builtin.meta: reset_connection
 
+# On a fresh VPS the user-manager restart above plus the connection reset
+# race against Tailscale SSH accepting a new session — the first reconnect
+# attempt would hard-fail and abort provisioning in the docker role before
+# any later role ran. wait_for_connection actively probes and retries until
+# the session is back instead of failing on the first try. Only fresh
+# installs hit this (the restart is when: changed), so gate it the same way.
+- name: Wait for SSH connection to re-establish after reset
+  ansible.builtin.wait_for_connection:
+    delay: 3
+    timeout: 120
+  when: docker_group_result.changed
+
 - name: Verify docker group membership is active
   ansible.builtin.shell: groups | grep -q docker
   args:
     executable: /bin/bash
   become: false
+  register: docker_group_verify
+  until: docker_group_verify.rc == 0
+  retries: 5
+  delay: 3
   changed_when: false
 
 # Create codex-proxy-net unconditionally for MCP containers (Codex, Claude Code, Pi)

--- a/ansible/roles/openclaw/tasks/onboard.yml
+++ b/ansible/roles/openclaw/tasks/onboard.yml
@@ -14,6 +14,13 @@
         mode: "0600"
       no_log: true
 
+    # --skip-health: onboarding deliberately uses --skip-daemon (the gateway
+    # service is installed later by daemon.yml). Since 2026.6.1, onboard runs a
+    # post-setup gateway health probe that, with no daemon yet running, fails
+    # with "Gateway did not become reachable" and exits non-zero — even though
+    # the config was written successfully. That error is not "gateway closed",
+    # so the tolerance check below would (wrongly) abort. --skip-health omits
+    # the probe entirely, which is correct for our deferred-daemon flow.
     - name: Run OpenClaw onboarding
       ansible.builtin.shell: |
         set -euo pipefail
@@ -27,7 +34,8 @@
             --gateway-port 18789 \
             --gateway-bind loopback \
             --skip-daemon \
-            --skip-skills 2>&1) || ONBOARD_EXIT=$?
+            --skip-skills \
+            --skip-health 2>&1) || ONBOARD_EXIT=$?
         if [ -n "${ONBOARD_EXIT:-}" ] && [ "$ONBOARD_EXIT" -ne 0 ]; then
             if echo "$ONBOARD_OUTPUT" | grep -q "gateway closed"; then
                 echo "Note: Ignoring expected 'gateway closed' error"


### PR DESCRIPTION
### What was built

Two fixes for fresh-VPS provisioning on openclaw 2026.6.1, both surfaced by the staging phoenix during the upgrade (#20) and both **fresh-install-only** (prod re-provisions skip these paths, which is why neither showed on prod):

1. **docker role — SSH reconnect race.** After adding `ubuntu` to the docker group + restarting the user systemd manager + `meta: reset_connection`, the first reconnect over Tailscale SSH on a fresh node hard-failed, aborting provisioning in the docker role before any later role ran. Fix: `wait_for_connection` (retry until back) + a retry on the group-membership verify.
2. **openclaw onboard — gateway health probe.** 2026.6.1 added a post-setup health probe to `openclaw onboard`. Our onboarding uses `--skip-daemon` (the gateway is installed later by `daemon.yml`), so the probe finds nothing listening, prints `Gateway did not become reachable`, and exits non-zero — even though the config wrote fine. Our error tolerance only ignored `gateway closed`, so it aborted. Fix: pass `--skip-health`.

### Why

Staging failed repeatedly during the 2026.6.1 upgrade. After clearing two stale-secret issues (expired `TS_AUTHKEY`), the run hit these two real code regressions in sequence: fix #1 let provisioning advance from the docker role to **72 tasks deep** (through the entire openclaw install + `doctor --fix` + heartbeat patch + auth), where it then hit #2 at onboarding. Both would break a fresh **prod** deploy too.

### Key decisions

- **docker:** `wait_for_connection` over a longer blind `pause` — it probes and returns as soon as the session is back. Gated `when: docker_group_result.changed` (mirrors the restart it follows); day-2 unchanged.
- **onboard:** `--skip-health` rather than broadening the tolerated-error grep — the probe is simply inappropriate for a flow that defers daemon install to a later role; not probing is cleaner than catching the failure after the fact.

### Files modified

- `ansible/roles/docker/tasks/main.yml` — `wait_for_connection` + verify retry after `reset_connection`
- `ansible/roles/openclaw/tasks/onboard.yml` — `--skip-health` on the onboard command

### Test plan

- [x] `ansible-playbook --syntax-check` passes
- [x] docker fix validated on a prior branch staging run — provisioning reached 72 tasks (past docker, through the openclaw role)
- [x] onboard `--skip-health` verified out-of-band: same command exits 0 and writes `openclaw.json` (the no-fix variant fails only on the health probe)
- [ ] Staging phoenix on this branch runs fully green through smoke test — first complete fresh-install validation of 2026.6.1

### Next steps

- Lingering tailnet ghosts `openclaw-staging*` (offline; one non-ephemeral from a cancelled run) — remove in the admin console; they force `-N` hostname suffixes on staging runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)