### PR TITLE
fix: green the staging phoenix on 2026.6.1 (device pairing + fresh-install harness)

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -233,11 +233,24 @@ jobs:
             | grep -oE "openclaw-staging(-[0-9]+)?" \
             | head -1)
           TAILNET=$(tailscale status --json | jq -r '.MagicDNSSuffix')
-          # Per-agent workspace services (workspace-git-sync-<agent_id>.service)
+          SSH="ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=accept-new ubuntu@${HOST}.${TAILNET}"
+          # A freshly-written unit is invisible to the user manager until a
+          # daemon-reload; the role notifies one, but reload before starting so
+          # this trigger never races it. Then list what exists for diagnostics.
+          $SSH "XDG_RUNTIME_DIR=/run/user/1000 systemctl --user daemon-reload"
+          echo "Workspace sync units present on host:"
+          $SSH "XDG_RUNTIME_DIR=/run/user/1000 systemctl --user list-unit-files 'workspace-git-sync-*' --no-legend --no-pager" || true
+          # Kick each per-agent sync. This is an auxiliary trigger — the workspace
+          # role already does the initial commit/push during deploy — so a missing
+          # unit warns loudly but must not sink the phoenix (verify + smoke are the
+          # real gates). A unit that exists but fails to start IS fatal.
           for agent in main test; do
-            ssh -o ConnectTimeout=30 -o StrictHostKeyChecking=accept-new \
-              "ubuntu@${HOST}.${TAILNET}" \
-              "XDG_RUNTIME_DIR=/run/user/1000 systemctl --user start workspace-git-sync-${agent}.service"
+            unit="workspace-git-sync-${agent}.service"
+            if $SSH "XDG_RUNTIME_DIR=/run/user/1000 systemctl --user cat ${unit} >/dev/null 2>&1"; then
+              $SSH "XDG_RUNTIME_DIR=/run/user/1000 systemctl --user start ${unit}"
+            else
+              echo "::warning::${unit} not present on host — skipping its sync trigger (workspace role may not have created it for this agent)"
+            fi
           done
 
       # ── Verify ───────────────────────────────────────────────────

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -336,7 +336,10 @@
           environment:
             XDG_RUNTIME_DIR: "/run/user/1000"
             PATH: "/home/ubuntu/.npm-global/bin:{{ ansible_facts['env']['PATH'] }}"
-            OPENCLAW_TOKEN: "{{ gateway_token }}"
+            # 2026.6.1 honours OPENCLAW_GATEWAY_TOKEN for SDK-level token
+            # injection; the old OPENCLAW_TOKEN is ignored (device approve then
+            # runs unauthenticated and silently no-ops).
+            OPENCLAW_GATEWAY_TOKEN: "{{ gateway_token }}"
           loop: "{{ pending_devices }}"
           loop_control:
             label: "{{ item.value.displayName | default(item.value.deviceId[:16]) }}"

--- a/ansible/roles/telegram/tasks/cron.yml
+++ b/ansible/roles/telegram/tasks/cron.yml
@@ -246,6 +246,43 @@
             GW_URL="{{ _tailscale_wss_url }}"
             GW_TOKEN="{{ _gw_token.stdout }}"
 
+            # The gateway is restarted immediately before this task (handlers are
+            # flushed) and on a fresh box its WS endpoint can be briefly unready,
+            # so retry transient cron CLI failures instead of aborting the whole
+            # provision on the first hiccup.
+            #
+            # A fresh gateway also requires the CLI device to be paired before WSS
+            # ops (cron add/remove/list) succeed; it returns a pairing-required
+            # error carrying a request id. Retrying alone never clears that, so on
+            # such an error we approve the pending request via OPENCLAW_TOKEN
+            # (SDK-level token injection, which bypasses the WSS pairing handshake
+            # the same way the auto-pair block above does) and then retry.
+            #
+            # On final failure, persist the error with the gateway token redacted
+            # so it stays diagnosable despite the no_log on this task.
+            CRON_ERR_FILE=/tmp/ansible-cron-error.txt
+            : > "$CRON_ERR_FILE"
+            retry_cron() {
+                local n=0 max=6 out rid
+                while :; do
+                    if out=$("$@" 2>&1); then printf '%s' "$out"; return 0; fi
+                    if printf '%s' "$out" | grep -qiE "pairing required|not approved"; then
+                        rid=$(printf '%s' "$out" | grep -oE "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" | head -1)
+                        if [ -n "$rid" ]; then
+                            OPENCLAW_TOKEN="$GW_TOKEN" openclaw devices approve "$rid" >/dev/null 2>&1 || true
+                        else
+                            OPENCLAW_TOKEN="$GW_TOKEN" openclaw devices list >/dev/null 2>&1 || true
+                        fi
+                    fi
+                    n=$((n + 1))
+                    if [ "$n" -ge "$max" ]; then
+                        printf '%s\n' "${out//$GW_TOKEN/<REDACTED_TOKEN>}" >> "$CRON_ERR_FILE"
+                        return 1
+                    fi
+                    sleep $((n * 3))
+                done
+            }
+
             # Build desired cron jobs as sorted JSON array (comparable fields only)
             DESIRED=$(jq -n '[]')
             {% for job in active_cron_jobs %}
@@ -287,7 +324,7 @@
                 # Recreate all managed jobs (throttled to avoid overwhelming gateway)
                 {% for job in active_cron_jobs %}
                 MSG=$(cat "/tmp/ansible-cron-msg-{{ job.name | hash('md5') }}")
-                openclaw cron add \
+                retry_cron openclaw cron add \
                     --name "{{ job.name }}" \
                     --cron "{{ job.schedule }}" \
                     --tz "{{ openclaw_timezone }}" \
@@ -295,7 +332,8 @@
                     --agent "{{ job.agent }}" \
                     --message "$MSG" \
                     --deliver --channel {{ agent_channel_map[job.agent] | default('telegram') }} --to "{{ agent_deliver_map[job.agent] }}" \
-                    --url "$GW_URL" --token "$GW_TOKEN"
+                    --url "$GW_URL" --token "$GW_TOKEN" \
+                    || { echo "ERROR: cron add failed for {{ job.name }} after retries" >&2; exit 1; }
                 sleep 1
                 {% endfor %}
 
@@ -306,9 +344,24 @@
           register: cron_sync_result
           changed_when: "'UPDATED' in cron_sync_result.stdout"
           no_log: true
+      rescue:
+        # The sync task is no_log (it embeds the gateway token), so its failure
+        # is censored. Surface the token-redacted error file the retry wrapper
+        # wrote, then re-fail. Safe to display: the token is already redacted.
+        - name: Read redacted cron error
+          ansible.builtin.command: cat /tmp/ansible-cron-error.txt
+          register: cron_err_redacted
+          changed_when: false
+          failed_when: false
+        - name: Show redacted cron error
+          ansible.builtin.debug:
+            msg: "{{ cron_err_redacted.stdout_lines | default(['(no captured error — failure was outside the cron CLI calls)']) }}"
+        - name: Re-fail after surfacing cron error
+          ansible.builtin.fail:
+            msg: "cron sync failed; see redacted gateway error above"
       always:
         - name: Clean up cron temp files
-          ansible.builtin.shell: rm -f /tmp/ansible-cron-list.json /tmp/ansible-cron-msg-*
+          ansible.builtin.shell: rm -f /tmp/ansible-cron-list.json /tmp/ansible-cron-msg-* /tmp/ansible-cron-error.txt
           args:
             executable: /bin/bash
           changed_when: false

--- a/ansible/roles/telegram/tasks/cron.yml
+++ b/ansible/roles/telegram/tasks/cron.yml
@@ -65,11 +65,13 @@
         # Read the gateway token from config
         GW_TOKEN=$(python3 -c "import json; print(json.load(open('/home/ubuntu/.openclaw/openclaw.json'))['gateway']['auth']['token'])")
 
-        # Use OPENCLAW_TOKEN env var (not --url/--token WSS) because device
-        # pairing operations must work BEFORE the CLI is paired. The WSS route
-        # requires pairing (chicken-and-egg), but OPENCLAW_TOKEN injects the
-        # token at the SDK level, bypassing the WebSocket pairing handshake.
-        DEVICES_OUT=$(OPENCLAW_TOKEN="$GW_TOKEN" openclaw devices list 2>&1) || {
+        # Use OPENCLAW_GATEWAY_TOKEN env var (not --url/--token WSS) because
+        # device pairing operations must work BEFORE the CLI is paired. The WSS
+        # route requires pairing (chicken-and-egg); OPENCLAW_GATEWAY_TOKEN
+        # injects the token at the SDK level, bypassing the WebSocket pairing
+        # handshake. (2026.6.1 renamed this from OPENCLAW_TOKEN, which is now
+        # ignored — the old name made approve run unauthenticated and no-op.)
+        DEVICES_OUT=$(OPENCLAW_GATEWAY_TOKEN="$GW_TOKEN" openclaw devices list 2>&1) || {
             echo "SKIP: devices list failed: $DEVICES_OUT" >&2
             exit 1
         }
@@ -82,8 +84,8 @@
             exit 1
         fi
 
-        # Approve via OPENCLAW_TOKEN (same reason as above)
-        OPENCLAW_TOKEN="$GW_TOKEN" openclaw devices approve "$REQUEST_ID"
+        # Approve via OPENCLAW_GATEWAY_TOKEN (same reason as above)
+        OPENCLAW_GATEWAY_TOKEN="$GW_TOKEN" openclaw devices approve "$REQUEST_ID"
         echo "PAIRED: approved request $REQUEST_ID"
       args:
         executable: /bin/bash
@@ -254,9 +256,9 @@
             # A fresh gateway also requires the CLI device to be paired before WSS
             # ops (cron add/remove/list) succeed; it returns a pairing-required
             # error carrying a request id. Retrying alone never clears that, so on
-            # such an error we approve the pending request via OPENCLAW_TOKEN
-            # (SDK-level token injection, which bypasses the WSS pairing handshake
-            # the same way the auto-pair block above does) and then retry.
+            # such an error we approve the pending request via
+            # OPENCLAW_GATEWAY_TOKEN (SDK-level token injection that bypasses the
+            # WSS pairing handshake, same as the auto-pair block above) and retry.
             #
             # On final failure, persist the error with the gateway token redacted
             # so it stays diagnosable despite the no_log on this task.
@@ -269,9 +271,9 @@
                     if printf '%s' "$out" | grep -qiE "pairing required|not approved"; then
                         rid=$(printf '%s' "$out" | grep -oE "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}" | head -1)
                         if [ -n "$rid" ]; then
-                            OPENCLAW_TOKEN="$GW_TOKEN" openclaw devices approve "$rid" >/dev/null 2>&1 || true
+                            OPENCLAW_GATEWAY_TOKEN="$GW_TOKEN" openclaw devices approve "$rid" >/dev/null 2>&1 || true
                         else
-                            OPENCLAW_TOKEN="$GW_TOKEN" openclaw devices list >/dev/null 2>&1 || true
+                            OPENCLAW_GATEWAY_TOKEN="$GW_TOKEN" openclaw devices list >/dev/null 2>&1 || true
                         fi
                     fi
                     n=$((n + 1))

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -269,7 +269,12 @@ CHANNELS_STATUS=$(ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=accept-new "
 check_channel() {
     local name="$1"
     local line
-    line=$(echo "$CHANNELS_STATUS" | grep -iE "^- $name" | head -1)
+    # `|| true`: an unconfigured channel (no matching line) makes grep exit 1,
+    # which under `set -euo pipefail` would kill the script at the assignment
+    # before the "not configured" branch below can handle it. Only bites when
+    # some channels are absent (staging runs Telegram only; prod has all three,
+    # so every grep matched and it never surfaced there).
+    line=$(echo "$CHANNELS_STATUS" | grep -iE "^- $name" | head -1 || true)
     if [[ -z "$line" ]]; then
         echo "   $name not configured (optional)"
     elif [[ "$line" == *"enabled"* ]]; then


### PR DESCRIPTION
### What was built

Four fresh-install fixes that take the staging phoenix from failing to **fully green end-to-end** (deploy → workspace-sync → verify → smoke) on openclaw 2026.6.1. Validated on a branch phoenix run: all gates pass, box destroyed cleanly.

### Why

After the docker + onboard fixes (#21) let provisioning reach the telegram role, the phoenix surfaced a chain of fresh-install-only issues — none of which touch prod day-2 (already-paired device, warm gateway, all channels present), which is why they only showed on a from-scratch deploy:

1. **Device pairing (the big one).** Cron sync over the WSS route failed deterministically with `device pairing required`. Root cause: the pairing automation injected the gateway token via `OPENCLAW_TOKEN`, but **2026.6.1 renamed the env var to `OPENCLAW_GATEWAY_TOKEN`** and ignores the old one — so every `openclaw devices approve` ran *unauthenticated* and silently no-op'd, leaving the CLI device unapproved. `smoke-test.sh` already used the correct name, which is why it worked and the role didn't.
2. **Cron robustness.** `retry_cron` now self-heals: on a pairing-required error it approves the pending request (correct env var) and retries; plus a redacted-error rescue that made the `no_log` failure diagnosable in the first place.
3. **Workspace-sync trigger.** Hard-failed the whole phoenix on a missing/!visible per-agent unit; now daemon-reloads, lists units for diagnostics, and warns (not fails) on a genuinely-absent unit — the role already does the initial commit/push during deploy, so this trigger is auxiliary to verify+smoke.
4. **verify.sh under set -e.** `check_channel` aborted the script when a channel was absent (staging runs Telegram only) because the unguarded `grep` exits 1 under `set -euo pipefail`. Guarded with `|| true`.

Also corrected the record: an earlier "deploy success" was a false positive — `staging.yml`'s `pulumi up ... || true` capacity-retry path had masked an ansible `failed=1`.

### Files modified

- `ansible/roles/telegram/tasks/cron.yml` — pairing self-heal + retry + redacted rescue
- `ansible/playbook.yml` — `OPENCLAW_GATEWAY_TOKEN` in the post-deploy pairing approval
- `.github/workflows/staging.yml` — robust workspace-sync trigger (daemon-reload + diagnostic + warn-on-missing)
- `scripts/verify.sh` — guard the channel grep under set -e

### Test plan

- [x] Branch phoenix run **green end-to-end**: deploy, workspace-sync, verify, smoke all pass; staging destroyed cleanly
- [x] ansible syntax + dynamic-include quote guard + shellcheck all pass

### Next steps

- Tailnet `openclaw-staging*` **ghost devices** (from the iteration runs) force `-N` hostname suffixes — verify.sh handles the suffix, but worth clearing in the Tailscale admin console.
- The `|| true` capacity-retry masking in staging.yml is worth revisiting separately (it hides ansible failures behind a green deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)