### PR TITLE
ci(lint): syntax-check dynamically-included task files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,11 @@
 #
 # Regression history: PR #15 shipped a YAML comment with an unbalanced
 # apostrophe that Ansible's Jinja2 pre-parser rejected. A bare
-# --syntax-check would have blocked the merge in seconds.
+# --syntax-check would have blocked the merge in seconds — BUT only for
+# statically-reachable tasks. A later apostrophe in cron.yml (pulled in via
+# dynamic `include_tasks`) slipped past `--syntax-check playbook.yml`
+# entirely and only failed at run time. The "Syntax-check included task
+# files" step below closes that gap by statically importing every task file.
 #
 # No secrets, no Pulumi, no Tailscale, no VPS. Should complete in under
 # a minute so it never becomes the bottleneck on a PR.
@@ -35,6 +39,11 @@ jobs:
       - name: Syntax-check playbook
         run: ansible-playbook --syntax-check -i localhost, playbook.yml
         working-directory: ansible
+
+      # Catches unbalanced quotes / Jinja in task files that the playbook pulls
+      # in via dynamic `include_tasks`, which the check above does not parse.
+      - name: Syntax-check included task files
+        run: ./scripts/check-task-syntax.sh
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/scripts/check-task-syntax.sh
+++ b/scripts/check-task-syntax.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Syntax-check every Ansible task file — including dynamically included ones.
+#
+# `ansible-playbook --syntax-check playbook.yml` only parses tasks reachable by
+# STATIC means (roles:, import_tasks, import_role). Files pulled in with
+# `include_tasks` (dynamic) are never parsed, so a templated shell block in one
+# of them with an unbalanced quote or Jinja block — e.g. an apostrophe in a
+# comment like `# this task's no_log` — sails past lint and only blows up at
+# run time with "failed at splitting arguments". (cron.yml hit exactly this.)
+#
+# This forces the parser through every task file by STATICALLY importing each
+# one into a throwaway playbook and syntax-checking that. Undefined vars are
+# fine — --syntax-check parses templates without evaluating them; the quote/
+# Jinja imbalance is a parse-level error and still surfaces.
+#
+# Usage: ./scripts/check-task-syntax.sh   (run from anywhere; needs ansible)
+
+set -euo pipefail
+
+ANSIBLE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../ansible" && pwd)"
+cd "$ANSIBLE_DIR"
+
+wrapper="$(mktemp -t ansible-task-syntax.XXXXXX.yml)"
+trap 'rm -f "$wrapper"' EXIT
+
+{
+  echo "- hosts: localhost"
+  echo "  gather_facts: false"
+  echo "  tasks:"
+  count=0
+  for f in roles/*/tasks/*.yml; do
+    [ -e "$f" ] || continue
+    echo "    - import_tasks: ${ANSIBLE_DIR}/${f}"
+    count=$((count + 1))
+  done
+  if [ "$count" -eq 0 ]; then
+    echo "ERROR: no task files found under roles/*/tasks/" >&2
+    exit 1
+  fi
+} > "$wrapper"
+
+echo "Syntax-checking $(grep -c import_tasks "$wrapper") task files (incl. dynamically included)..."
+ansible-playbook --syntax-check -i localhost, "$wrapper"
+echo "OK: all task files parse cleanly."


### PR DESCRIPTION
### What was built

A lint step that statically syntax-checks **every** Ansible task file, including those pulled in via dynamic `include_tasks` — which the existing `--syntax-check playbook.yml` never parses.

### Why

`ansible-playbook --syntax-check` only walks statically-reachable tasks. A templated `shell:` block in a dynamically-included file with an unbalanced quote (e.g. an apostrophe in a comment, `# this task's no_log`) sails past lint and fails only at **run time** with `failed at splitting arguments, either an unbalanced jinja2 block or quotes`. This is the exact regression class `lint.yml` was created for (PR #15), but the existing check is blind to dynamic includes — and it has now bitten twice (most recently in `cron.yml`, caught only by a ~25-min staging run instead of a 30-second lint).

Notably, `ansible-lint` does **not** catch this either (verified): linting a standalone task file never runs the arg-splitter, and graph-walking never reaches a dynamic include. The only thing that surfaces it statically is forcing the parser through the file via a static `import_tasks` + `--syntax-check`.

### Files added/modified

- `scripts/check-task-syntax.sh` (new) — generates a throwaway playbook that `import_tasks` every `roles/*/tasks/*.yml`, then `--syntax-check`s it. Runnable locally pre-push.
- `.github/workflows/lint.yml` — new "Syntax-check included task files" step in the existing `ansible-syntax` job (no new dependency; ansible already installed).

### Test plan

- [x] Passes clean on the current tree (`exit 0`, all task files parse)
- [x] Negative control: apostrophe injected into any `shell:` block → `exit 4`, `unbalanced ... quotes` reported
- [x] `shellcheck -S error scripts/check-task-syntax.sh` clean (the other lint job would gate on this)
- [x] `ansible-lint` confirmed to *miss* the same bug (motivates this approach over adding ansible-lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)