### PR TITLE
ansible(plugins): make Claude Code plugin list a per-deployment override

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -233,26 +233,15 @@ openclaw_mcp_server_types:
   - type: "node-exec"
     name_prefix: "mac"
 
-# Claude Code plugins for MCP containers
-claude_code_plugins:
-  config_dir: "/home/ubuntu/.openclaw/claude-code-plugins"
-  marketplaces:
-    - repo: "anthropics/claude-plugins-official"
-    - repo: "pandysp/claude-plugins"
-    - repo: "astral-sh/claude-code-plugins"
-  plugins:
-    - "code-review"
-    - "code-simplifier"
-    - "commit-commands"
-    - "feature-dev"
-    - "frontend-design"
-    - "hookify"
-    - "plugin-dev"
-    - "pr-review-toolkit"
-    - "ralph-loop"
-    - "security-guidance"
-    - "astral@astral-sh"
-    - "typescript-lsp@pandysp"
+# Claude Code plugins installed into the VPS agents' `claude` CLI.
+#
+# Intentionally NOT defaulted here: which plugins a deployment wants is a
+# per-deployment choice, and a hardcoded list silently rots when upstream
+# marketplaces change (e.g. a plugin removed from its marketplace breaks
+# provisioning). Define `claude_code_plugins` in group_vars/openclaw.yml to
+# enable it — see openclaw.yml.example for the structure. When it is undefined
+# the plugins role simply skips Claude Code plugin install
+# (`when: claude_code_plugins is defined`).
 
 # Obsidian Headless Sync (obsidian-headless npm package)
 # Runs per-workspace sync daemons for near-real-time Obsidian Sync cloud access.

--- a/ansible/group_vars/openclaw.yml.example
+++ b/ansible/group_vars/openclaw.yml.example
@@ -111,6 +111,24 @@
 # # Override excluded folders (default: .git,.venv,node_modules,.cache,.env)
 # obsidian_headless_excluded_folders: ".git,.venv,node_modules,.cache,.env,.claude"
 
+# --- Claude Code plugins (optional) ---
+# Plugins installed into the VPS agents' `claude` CLI. This is a per-deployment
+# choice and is NOT defaulted in all.yml — define it here to enable it. Each
+# entry is a plugin name (resolved from any added marketplace) or
+# "<plugin>@<marketplace-owner>" to pin it to a specific marketplace. Keep this
+# in sync with the marketplaces — a plugin that no longer exists in its
+# marketplace fails provisioning.
+#
+# claude_code_plugins:
+#   config_dir: "/home/ubuntu/.openclaw/claude-code-plugins"
+#   marketplaces:
+#     - repo: "anthropics/claude-plugins-official"
+#     - repo: "astral-sh/claude-code-plugins"
+#   plugins:
+#     - "code-review"
+#     - "feature-dev"
+#     - "astral@astral-sh"
+
 # --- Advanced: manual overrides for auto-generated config ---
 # The following variables are normally auto-generated from openclaw_agents.
 # Define them here ONLY if you need non-standard naming or custom server configurations.


### PR DESCRIPTION
Moves `claude_code_plugins` out of committed `all.yml` into the gitignored `openclaw.yml` (per-deployment choice), and documents it in `openclaw.yml.example`.

**Why:** the list was hardcoded in shared code, imposed one opinionated set on every deployment, and silently rotted when upstream marketplaces changed — `typescript-lsp@pandysp` was removed from its marketplace and broke provisioning (the branch run had passed before the upstream removal). It also didn't match what's actually used.

**Behavior:** the plugins role already guards `when: claude_code_plugins is defined`, so removing the default cleanly disables Claude Code plugin install unless a deployment opts in. The CI staging phoenix no longer installs Claude Code plugins (its generated config doesn't set the var) — removing a flaky git-clone step from the pipeline.

My local `openclaw.yml` (gitignored, not in this PR) now carries the real set, mirrored from the actually-enabled plugins in the session.