### PR TITLE
mac: system-daemon deployer + prep-only workspace/qmd generators

### DIFF
--- a/docs/mac-daemon-audit.md
+++ b/docs/mac-daemon-audit.md
@@ -1,0 +1,240 @@
+# Mac Daemon Audit — Prioritized Remediation Plan
+
+**Goal:** every macOS account on every machine (spannagel + tl on the Mac Studio, andreasspannagel on the MacBook Air) runs an **identical** set of workspace daemons — git-sync, obsidian-headless, qmd-watch, qmd-http for all agents — all **ACTIVE**, login-independent, with full redundancy. Identical beats minimal: the Air runs system daemons for *uniformity*, not because it needs them.
+
+**Synthesized from three dimension audits:** Homebrew multi-user hazard, Node-major / native-module fragility, and daemon-architecture migration. All live readings below are verified on the Air (`andreasspannagel`, node 26.3.0, ABI 147, umask 022) and cross-referenced against the Studio readings in the dimension reports.
+
+---
+
+## Execution status (live)
+
+- **P0 DONE** — both generators trimmed to prep-only (workspaces also gains a positional agent filter and pins Node 23.11.0 for its `ob` calls; ob's better-sqlite3 12.6.2 is ABI-locked to Node 23). Committed alongside the deployer.
+- **Air (`andreasspannagel`) DONE** — 8/9 agents × 4 daemons live as system LaunchDaemons (qmd-http ports 8391–8399), all `loaded` + qmd-http `responding`, superseded GUI LaunchAgents torn down. Idle footprint ≈ 1.8 GB on 24 GB (system 65% free).
+- **`volki` BLOCKED on every Mac** — 2 Notion-export files carry invalid-UTF-8 (Latin-1) bytes in their names (`notion-contacts/Renée Ruch …`, `Sven Förstmann …`); APFS rejects them, aborting clone checkout, and a partial clone would make git-sync push mass deletions. Quarantined (not cloned). Fix at source: rename via `iconv -f latin1 -t utf8`, commit, push — then it deploys like the rest.
+- **PENDING** — Studio accounts `spannagel` + `tl` (main done; the other 8 agents need prep + deploy). P1/P2/P3 hygiene remain deferred: the deployer's Node-23 pin works, so P2 is not blocking the rollout.
+
+---
+
+## The centerpiece already exists
+
+A prior session wrote **`scripts/deploy-mac-daemons.sh`** (548 lines, currently **uncommitted**). It already solves the hard parts of the daemon-architecture dimension, cleanly:
+
+- per-account daemon labels `com.openclaw.<svc>.<account>.<agent>` (no system-domain collision),
+- account-indexed qmd-http ports `8191 + accountIndex*100 + agentPosition` (no cross-account bind collision; retires the hand-dodged 8291 PoC),
+- per-account qmd-watch locks `/tmp/qmd-watch-<account>-<agent>.lock` (no cross-account `/tmp` deadlock),
+- a **scan-based system-domain uninstall** (the old generators' uninstall only scanned `gui/N` and could never see system daemons),
+- **teardown of the superseded GUI LaunchAgents** *after* the daemons are up (closes the double-run-on-login trap),
+- `UserName` + `HOME` pinned in every plist (daemon runs **as** the account, writes the right home),
+- correct main targeting: `workspace_dir_for` special-cases the default agent to `$HOME/main-workspace` (verified in `lib/agents.sh:55`) — main's `INDEX_PATH` is **not** mis-pointed under `dev/personal/workspaces`.
+
+**This plan is built around adopting that script, not replacing it.** What remains is (a) making it safe to run by neutering the old generators, (b) committing it, (c) fixing the two fragility/hazard dimensions it doesn't touch, and (d) rolling it out to all accounts and agents.
+
+**Leverage = (what it gates) × (blast radius if skipped).** That discriminator, not a fixed order, sets the sequence below.
+
+---
+
+## P0 — Commit the deployer **and** de-conflict the old generators (one indivisible change)
+
+**Problem (one line):** the deploy script supersedes the plist halves of `setup-mac-workspaces.sh` and `setup-mac-qmd.sh`, but those generators still emit GUI LaunchAgents — the next prep run re-creates them and double-runs main's qmd/obsidian against a live system daemon = **sqlite corruption, not wasted CPU**.
+
+**Why these ship together:** committing the deployer alone is *more* dangerous than not committing it (it invites prep re-runs that resurrect the agents); de-conflicting alone leaves the deployer uncommitted and un-reproducible. Ship as one commit.
+
+**Clean fix:**
+
+1. In `scripts/setup-mac-workspaces.sh` and `scripts/setup-mac-qmd.sh`, **keep** workspace prep + helper-script install (`workspace-git-sync-<agent>.sh`, `qmd-watch-<agent>.sh` in `~/.local/bin`, vault link, index build) — the deployer *reuses* those helpers — and **remove only** the plist emit / `launchctl bootstrap gui` / agent-load blocks. Surgical excision, not deletion. Leave a one-line pointer at the top of each: workspace + helper prep only; daemon deployment is `deploy-mac-daemons.sh`.
+2. Commit the deployer + the trimmed generators together, staging **named files only** (the tree carries unrelated in-flight work — the opus-4-8 model bump in `group_vars/all.yml` and the heartbeat-shadow fix in `roles/agents/tasks/main.yml`):
+
+```bash
+cd ~/dev/personal/openclaw-infra
+git checkout -b mac-system-daemons
+git add scripts/deploy-mac-daemons.sh \
+        scripts/setup-mac-workspaces.sh \
+        scripts/setup-mac-qmd.sh \
+        scripts/templates/qmd-watch-mac.sh.tmpl   # see P3
+# NEVER `git add -A` here — it would sweep in the unrelated model/heartbeat work.
+```
+
+**Risk:** the trimmed generators must still install the helper scripts the deployer depends on; if a refactor drops a helper, the deployer warns-and-skips that service (it already guards each prereq) rather than failing loud — verify each service deploys after the trim, don't trust the skip path.
+
+**One-time or encoded?** **Encoded.** This *is* the encoding of the migration into the repo. The migration currently exists only as hand-applied live plists on the Studio; this is what makes it reproducible.
+
+---
+
+## P1 — Homebrew multi-user: close the umask hole on `/opt/homebrew`
+
+**Problem (one line):** a single shared `/opt/homebrew` prefix; runtime-born dirs (`var/homebrew/locks/`, new keg dirs, prefix root) are created under umask 022 → `0755`, so the *other* admin account can't create/delete entries and `brew` aborts (the `python@3.14` lock collision).
+
+**Root cause — corrected from the original brief:** it is **not** a missing setgid bit. macOS BSD semantics already force group `admin` onto everything Homebrew creates (proven in isolation in the dimension report; documented in Homebrew's own FAQ), so group *ownership* is solved. setgid is redundant on macOS. The missing thing is the **group-write mode bit**, and the generator that strips it is **umask 022**. Files (`0644`) are irrelevant — multi-user contention is over **directory** entry-management rights only.
+
+**Live state (Air, original/tight — the disease):**
+```
+drwxr-xr-x  andreasspannagel:admin  /opt/homebrew                     (0755, NOT g-writable)
+drwxr-xr-x  andreasspannagel:admin  /opt/homebrew/var/homebrew/locks  (0755, NOT g-writable) ← the blocker
+umask = 022
+```
+Studio is in a *different* state: already hand-patched (`locks` 0777, root 0775) — a band-aid that still decays on the next new-formula install because umask is unchanged. **The fix must be applied uniformly to all three homes**, or band-aid and disease coexist and drift.
+
+**Clean fix — two parts:**
+
+1. **One-time repair** of the current tree (root is fine for a chmod/chgrp sweep; Homebrew's no-sudo guard is about `brew` build scripts, not `chmod`):
+```bash
+sudo chgrp -R admin /opt/homebrew
+sudo chmod -R g+w   /opt/homebrew   # fixes prefix root, Homebrew/Library, var/homebrew/locks
+```
+This restores the current tree but does **not** hold — the next `brew install <new-formula>` mints fresh `0755` dirs.
+
+2. **Durability — inherited ACL scoped to the prefix** (preferred over a global umask change, see risk):
+```bash
+sudo chmod -R +a "group:admin allow \
+read,write,execute,delete,add_file,add_subdirectory,file_inherit,directory_inherit" /opt/homebrew
+# VERIFY before trusting: ls -le /opt/homebrew, then a real two-account `brew install <new formula>` test.
+```
+
+**Risk (keep these hedges — they are the honest signal):**
+- The **ACL command syntax is reconstructed**, not run. Verify with `ls -le` and a two-account install before committing it as canonical.
+- The alternative durability lever — global `umask 002` — has a **large blast radius**: the primary group on macOS is `staff` (gid 20, ~all local users), so global 002 makes *every* file you create anywhere group-writable by staff. That broad loosening is the decisive reason to prefer the path-scoped ACL.
+- Whole-tree `g+w` also loosens `bin/`; both accounts already `sudo`, so on a 2-admin box this is minor, but name it: either admin can replace an installed binary without escalation.
+- Multi-user Homebrew is **officially unsupported** ("does not work well in multi-user configurations" — Homebrew FAQ). This is a community workaround on an unsupported topology; a future Homebrew change could alter the inheritance/mode assumptions. `brew doctor` may flag non-standard perms/ACLs.
+
+**One-time or encoded?** **Both.** One-time repair now on all three homes; the chgrp + ACL must be **encoded** as an ansible task / setup-script step in the Homebrew role so a fresh box and every re-provision re-applies it (otherwise it decays back to the band-aid-or-disease split).
+
+---
+
+## P2 — Native-module fragility: make the build survive a reinstall (the real durable fix)
+
+**Problem (one line):** both ob and qmd load a V8-ABI `better_sqlite3.node`; ob's is a **hand-placed, unreproducible** artifact (12.6.2 has no node-26 prebuild and won't compile on node 26), and qmd's `better-sqlite3` isn't in bun's trust list — so any `pnpm/bun install` or store GC strips the `.node` and the daemon crashloops.
+
+**Correction to the brief:** qmd is **not** shielded by bun. `~/.bun/bin/qmd`'s shebang is `#!/usr/bin/env node` with `exec node` primary — qmd runs under PATH node, so its better-sqlite3 is V8-ABI-keyed exactly like ob's. The fragility is **symmetric**.
+
+**Two distinct failure classes — don't conflate:**
+- **ABI-on-bump (better-sqlite3 only):** binary keyed to NODE_MODULE_VERSION; node major bump → `ERR_DLOPEN_FAILED` crashloop (the 2.1 GB-log incident). Only better-sqlite3 dies on a major; node-llama-cpp and tree-sitter are N-API/prebuild and survive.
+- **Build-survives-reinstall (llama, tree-sitter, better-sqlite3's *build*):** lifecycle scripts skipped unless the dep is trusted; pnpm store GC can orphan an out-of-band `.node`.
+
+### P2a — qmd: trust `better-sqlite3` in the bun global manifest
+
+**Live state:** bun global `trustedDependencies` lists node-llama-cpp + tree-sitters but **not** `better-sqlite3` — which is why its `.node` was rebuilt-in-place and why every `bun install -g` reinstall restores a stale/wrong-ABI build.
+
+```bash
+cd ~/.bun/install/global
+bun pm trust better-sqlite3   # adds to trustedDependencies + builds now
+bun pm trusted                # verify better-sqlite3 appears
+```
+
+### P2b — ob: bump the dependency, don't freeze the runtime
+
+**The Node-23 pin is the wrong axis.** The deploy script hard-pins Node 23.11.0 for obsidian (`OBSIDIAN_NODE_BIN`, lines 116–120) purely to satisfy ob's stale 12.6.2 binary — coupling a daemon's runtime to one transitive dep's stale ABI, and the binary is *still* hand-built. The durable fix is to **bump better-sqlite3 to 12.10.0** (same major → API-stable by semver; has a node-26 prebuild) and **stop installing globally** so a real manifest carries the pin.
+
+`pnpm -g` has no project manifest you can put `overrides`/`onlyBuiltDependencies` in — that's why the global install is unfixable in place. Replace it with a managed pin-project (one per machine, templated into the repo):
+
+```jsonc
+// ~/.openclaw/ob-runtime/package.json
+{
+  "name": "ob-runtime", "private": true,
+  "dependencies": { "obsidian-headless": "0.0.12" },
+  "pnpm": {
+    "overrides": { "better-sqlite3": "12.10.0" },
+    "onlyBuiltDependencies": ["better-sqlite3"]
+  }
+}
+```
+```bash
+echo "26.3.0" > ~/.openclaw/ob-runtime/.node-version
+cd ~/.openclaw/ob-runtime && pnpm install
+# artifact is now DERIVABLE: rm -rf node_modules && pnpm install reproduces it on any node major
+# 12.10.0 prebuilds (24/25/26+). No hand-placed .node, no node-version coupling.
+```
+
+**Sequencing the runtime transition (the unverified step gates the flip):**
+1. P2a + build the ob-runtime project (keep the Node-23 pin in the deploy script meanwhile — interim that the durable fix retires).
+2. **Smoke-test `ob sync-status` against the 12.10.0 build** on one account.
+3. Only then point the deploy script at the new binary — 3 edits: add `~/.openclaw/ob-runtime/node_modules/.bin/ob` to `resolve_ob_bin`'s candidate list, drop `OBSIDIAN_NODE_BIN` from `OBSIDIAN_PATH`, update the pin comment.
+
+**Also fix the stale version pins** (so the repo stops disagreeing with reality):
+- `ansible/group_vars/all.yml:142` — `qmd_version: "2.0.1"` is stale; installed is **2.5.3**. Bump it.
+- `nodejs_major_version: 25` (all.yml) disagrees with live node 26 and mise's `26.3.0` pin. Pick one SoT.
+
+**Risk (keep the hedges):**
+- **12.10.0 as a drop-in for ob 0.0.12 is unverified.** Same major → low risk, but smoke-test before rolling to all agents (this is the gate above).
+- ob declares `engines.node >=22.0.0` — node 26 satisfies it, no engine fight.
+
+**One-time or encoded?** **Encoded.** P2a → a `bun pm trust better-sqlite3` task in `roles/qmd`. P2b → template the `ob-runtime` project + `.node-version` in `roles/obsidian-headless` / `setup-mac-workspaces.sh`, replacing the bare `pnpm install -g`; plist points at the project's `.bin/ob`. Plus a post-install `qmd status` / `ob sync-status` gate that fails loud on `ERR_DLOPEN_FAILED` instead of crashlooping.
+
+---
+
+## P3 — Clean win: namespace the qmd-watch lock at the template, not post-hoc
+
+**Problem (one line):** `scripts/templates/qmd-watch-mac.sh.tmpl:12` emits `AGENT_LOCK="/tmp/qmd-watch-__AGENT_ID__.lock"` (no account), so the deploy script mutates it afterward with an in-place `sed` — a fragile post-hoc rewrite anchored on `^AGENT_LOCK=`.
+
+**Clean fix:** add an account token to the template so the helper is born correctly namespaced, and drop `namespace_qmd_watch_lock` + its `sed` call from the deploy script:
+```
+AGENT_LOCK="/tmp/qmd-watch-__ACCOUNT__-__AGENT_ID__.lock"
+```
+The generator that renders the template substitutes `__ACCOUNT__` = `$(id -un)`. `EMBED_LOCK="/tmp/qmd-embed-global.lock"` stays machine-global by design (one 314 MB embedding model load at a time across all accounts) — leave it.
+
+**Risk:** low. Verify the renderer substitutes the new token; a missed substitution would leave a literal `__ACCOUNT__` in the lock path (harmless but ugly — catch it in the deploy `--status` smoke run).
+
+**One-time or encoded?** **Encoded** (template change), and it *removes* live mutation logic — net simplification.
+
+---
+
+## P4 — Roll out to all accounts and all agents (depends on P0–P3 being safe)
+
+**Problem (one line):** coverage is 1/9 agents on the Studio (spannagel.main full; tl.main = qmd-http PoC only on 8291), 0 system daemons on the Air; 7–8 of 9 agents on spannagel are **not active at all**. "Identical + active everywhere" is far off.
+
+**Why last:** rollout multiplies whatever state P0–P3 leave behind. Run it only after the deployer is safe to run (P0), tools are installable on both Studio accounts (P1), and a reinstall won't strip the `.node` (P2). The agent set is the 9 in `lib/agents.sh`: `main, manon, tl, henning, ph, nici, volki, franca, cama`.
+
+**Clean fix:** run the deployer per account, per machine. It is idempotent and re-runnable; it tears down the matching GUI LaunchAgents in the same pass.
+```bash
+# On each account (spannagel, tl on Studio; andreasspannagel on Air), after prep has run:
+~/dev/personal/openclaw-infra/scripts/deploy-mac-daemons.sh           # all agents
+~/dev/personal/openclaw-infra/scripts/deploy-mac-daemons.sh --status  # verify loaded + health
+```
+Account → port-base index is already mapped (spannagel 0, tl 1, andreasspannagel 2), overridable via `OPENCLAW_ACCOUNT_INDEX`; unknown accounts hard-fail rather than silently colliding on base 8191.
+
+**Risk:**
+- **tl double-runs the instant a system daemon loads** while its matching GUI LaunchAgent is still live (tl is always-logged-in). The deployer's teardown handles this *for agents it knows*, but verify no stray tl agent for `main` survives the PoC era — and retire the 8291 PoC daemon explicitly (it's off the positional scheme; `--uninstall` for tl then redeploy).
+- **spannagel's dormant GUI agents become a footgun on first console login** — they'd double-write main's index. The deployer's `rm` of the old plists neutralizes this; confirm `~/Library/LaunchAgents` is clean of `com.openclaw.*`/`com.qmd.*` after deploy.
+- workspace/index prereqs must exist per agent or the deployer warns-and-skips — run prep first; a silent skip means that agent has no daemon.
+
+**One-time or encoded?** Execution is per-machine one-time, but the *deployer itself* is the encoding. Ideally wrap the per-account invocation in the ansible play so re-provision re-runs it.
+
+---
+
+## Ordered rollout checklist
+
+Run top-to-bottom. Each Studio step is done on **both** Studio accounts (spannagel, tl); Air steps on `andreasspannagel`.
+
+**Phase A — encode (repo, on the Air; no live daemon impact yet)**
+1. `git checkout -b mac-system-daemons`.
+2. Trim `setup-mac-workspaces.sh` + `setup-mac-qmd.sh` to prep+helpers only (remove plist emit/load) — **P0**.
+3. Namespace `qmd-watch-mac.sh.tmpl` with `__ACCOUNT__`; drop the deploy script's `namespace_qmd_watch_lock` sed — **P3**.
+4. Bump `qmd_version` 2.0.1 → 2.5.3 and reconcile `nodejs_major_version` 25 → 26 in `group_vars/all.yml` — **P2**.
+5. `git add` the **named** daemon/template/version files only (never `-A` — unrelated opus-4-8 + heartbeat work is in the tree). Commit.
+
+**Phase B — fragility & hazard groundwork (each account, each machine)**
+6. **P1** one-time repair: `sudo chgrp -R admin /opt/homebrew && sudo chmod -R g+w /opt/homebrew` on all three homes; then apply the inherited ACL, **verify with `ls -le` + a two-account `brew install`** before trusting it.
+7. **P2a:** `cd ~/.bun/install/global && bun pm trust better-sqlite3 && bun pm trusted`.
+8. **P2b:** create `~/.openclaw/ob-runtime` (manifest + `.node-version`), `pnpm install`, then **smoke-test `ob sync-status`** on the 12.10.0 build. Gate: do not proceed to step 9 until this passes.
+9. Point the deploy script's `resolve_ob_bin` at `~/.openclaw/ob-runtime/node_modules/.bin/ob`; drop `OBSIDIAN_NODE_BIN` from `OBSIDIAN_PATH`. Re-commit.
+
+**Phase C — deploy (each account, each machine; prep first)**
+10. Run the trimmed prep (`setup-mac-workspaces.sh`, `setup-mac-qmd.sh`) so helpers/indexes exist for all agents.
+11. Retire the tl 8291 PoC: `deploy-mac-daemons.sh --uninstall` as tl, confirm 8291 down.
+12. `deploy-mac-daemons.sh` (all agents) on each account.
+13. `deploy-mac-daemons.sh --status` — every service `loaded`, qmd-http `responding`. Confirm `~/Library/LaunchAgents` has no leftover `com.openclaw.*` / `com.qmd.*`.
+14. Cross-account sanity: a single curl sweep of `localhost:8191–8199, 8291–8299, 8391+` shows each account's ports up and **no port served twice**.
+
+**Phase D — verify redundancy & ship**
+15. Reboot one machine (or `launchctl bootout`/`bootstrap` cycle); confirm daemons come back **without any GUI login** — the redundancy guarantee.
+16. Re-run `pnpm install` in `ob-runtime` and `bun install -g` for qmd; confirm both daemons stay up (the `.node` is reproduced, not stripped) — proves P2 holds.
+17. Open PR on `mac-system-daemons`; encode the per-account `deploy-mac-daemons.sh` invocation + P1/P2 tasks into the ansible plays so re-provision is fully reproducible.
+
+---
+
+## Caveats (carried forward verbatim from the dimension audits)
+
+- **ACL syntax (P1) is reconstructed, not executed** — verify with `ls -le` and a two-account install before treating it as canonical.
+- **better-sqlite3 12.10.0 as a drop-in for ob 0.0.12 is unverified** — same major, low risk, but the `ob sync-status` smoke-test (step 8) is a hard gate.
+- **Multi-user Homebrew is officially unsupported** — this is a workaround on an unsupported topology; `brew doctor` may complain and a future Homebrew release could break the inheritance/mode assumptions.
+- **Studio daemons' `launchctl list` "loaded" state** was not re-verified with root this session; "responding" (curl health) is proven for 8191/8291, which is the half that matters for "active."
+- The tree carries **unrelated in-flight work** (opus-4-8 model bump, heartbeat-shadow fix) — stage daemon files by name, never `git add -A`.

--- a/scripts/deploy-mac-daemons.sh
+++ b/scripts/deploy-mac-daemons.sh
@@ -1,0 +1,584 @@
+#!/usr/bin/env bash
+# Deploy openclaw workspace services as per-account *system* LaunchDaemons.
+#
+# Why daemons, not LaunchAgents: a Mac Studio is shared by two accounts
+# (spannagel, tl) that are usually NOT logged into the GUI. Per-user
+# LaunchAgents only run while their owner has an active GUI (Aqua) session, so
+# the workspace services die whenever the account is logged out. System
+# LaunchDaemons in /Library/LaunchDaemons run login-independent; each carries a
+# <UserName> key so launchd still runs the program AS the target account.
+#
+# Four services per agent workspace (mirrors the two LaunchAgent generators
+# this replaces — setup-mac-workspaces.sh + setup-mac-qmd.sh):
+#   git-sync         hourly git backup (StartCalendarInterval :30)
+#   obsidian-headless continuous Obsidian Sync (KeepAlive)
+#   qmd-watch        fswatch-driven qmd reindex (KeepAlive)
+#   qmd-http         qmd MCP HTTP endpoint (KeepAlive)
+#
+# Everything is namespaced per account so two accounts on one Mac never collide:
+#   - daemon label:   com.openclaw.<svc>.<account>.<agent>
+#   - qmd-http port:   8191 + accountIndex*100 + agentPositionInFullList
+#   - qmd-watch lock:  /tmp/qmd-watch-<account>-<agent>.lock
+#   (the qmd embed lock stays machine-global: /tmp/qmd-embed-global.lock, so two
+#    accounts never load the 314MB embedding model at the same time.)
+#
+# This script does NOT do workspace prep (git init, vault linking, index build).
+# Those one-time steps still live in the two LaunchAgent generators and must
+# have been run first. This script only (re)deploys the daemons and tears down
+# the superseded per-user LaunchAgents so they can't double-run on a future GUI
+# login.
+#
+# Reuses the per-agent helper scripts the existing generators install in
+# ~/.local/bin (workspace-git-sync-<agent>.sh, qmd-watch-<agent>.sh) and reads
+# the agent list + path helpers from lib/agents.sh (the openclaw.yml SoT).
+#
+# Run AS the target account (sudo is used only for the /Library writes and the
+# `launchctl ... system` calls). Idempotent and re-runnable.
+#
+# Usage:
+#   ./scripts/deploy-mac-daemons.sh                 # all agents, current account
+#   ./scripts/deploy-mac-daemons.sh main tl          # only these agents
+#   ./scripts/deploy-mac-daemons.sh --status         # show daemon status
+#   ./scripts/deploy-mac-daemons.sh --uninstall      # remove this account's daemons
+#
+# Env:
+#   OPENCLAW_ACCOUNT_INDEX  override the account->port-base index (0/1/2/...)
+
+set -euo pipefail
+
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+    echo "ERROR: requires bash 4+ (got ${BASH_VERSION:-unknown}); invoke with Homebrew bash, not /bin/bash." >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=scripts/lib/agents.sh
+source "$SCRIPT_DIR/lib/agents.sh"
+
+# --- Account + identity ------------------------------------------------------
+
+ACCOUNT="$(id -un)"
+ACCOUNT_UID="$(id -u)"
+HOME_DIR="$HOME"
+
+WORKSPACES_DIR="$HOME_DIR/dev/personal/workspaces"
+BIN_DIR="$HOME_DIR/.local/bin"
+LOG_DIR="$HOME_DIR/Library/Logs/openclaw"
+USER_LAUNCH_AGENTS_DIR="$HOME_DIR/Library/LaunchAgents"
+SYSTEM_DAEMONS_DIR="/Library/LaunchDaemons"
+GUI_DOMAIN="gui/$ACCOUNT_UID"
+
+# qmd HTTP port base; +100 per account, +1 per agent (positional, full list).
+QMD_HTTP_BASE_PORT=8191
+
+log()  { echo "==> $*"; }
+warn() { echo "WARNING: $*" >&2; }
+die()  { echo "ERROR: $*" >&2; exit 1; }
+
+# Authenticate sudo once, non-interactively when possible. Over SSH there is no
+# tty for a password prompt, so set SUDO_ASKPASS to a helper that prints the
+# password and this uses `sudo -A`. Falls back to an interactive prompt when a
+# real terminal is present. Once primed, later plain `sudo` calls use the cache.
+sudo_prime() {
+    sudo -n -v 2>/dev/null && return 0
+    [ -n "${SUDO_ASKPASS:-}" ] && sudo -A -v 2>/dev/null && return 0
+    sudo -v 2>/dev/null && return 0
+    die "sudo is required to manage ${SYSTEM_DAEMONS_DIR} and the system launchd domain. Pre-authenticate sudo, or set SUDO_ASKPASS=<helper> for non-interactive (SSH) use."
+}
+
+# --- Account index -> port-base offset ---------------------------------------
+# OPENCLAW_ACCOUNT_INDEX wins; else map known accounts; else hard-fail. We never
+# default an unknown account to 0 — that would silently collide port bases with
+# spannagel across machines.
+resolve_account_index() {
+    if [ -n "${OPENCLAW_ACCOUNT_INDEX:-}" ]; then
+        case "$OPENCLAW_ACCOUNT_INDEX" in
+            ''|*[!0-9]*) die "OPENCLAW_ACCOUNT_INDEX must be a non-negative integer (got: '$OPENCLAW_ACCOUNT_INDEX')" ;;
+        esac
+        echo "$OPENCLAW_ACCOUNT_INDEX"
+        return
+    fi
+    case "$ACCOUNT" in
+        spannagel)        echo 0 ;;
+        tl)               echo 1 ;;
+        andreasspannagel) echo 2 ;;
+        *) die "Unknown account '$ACCOUNT' — no port-base index mapping. Set OPENCLAW_ACCOUNT_INDEX=<n> explicitly." ;;
+    esac
+}
+ACCOUNT_INDEX="$(resolve_account_index)"
+
+# --- Daemon labels (new, per-account) ----------------------------------------
+# com.openclaw.<svc>.<account>.<agent>
+daemon_label()  { echo "com.openclaw.$1.${ACCOUNT}.$2"; }   # $1=svc $2=agent
+daemon_plist()  { echo "$SYSTEM_DAEMONS_DIR/$(daemon_label "$1" "$2").plist"; }
+
+# Reused helper scripts installed by the existing generators in ~/.local/bin.
+git_sync_script()  { echo "$BIN_DIR/workspace-git-sync-$1.sh"; }
+qmd_watch_script() { echo "$BIN_DIR/qmd-watch-$1.sh"; }
+
+# Old per-user LaunchAgent plists this deployment supersedes. Hardcoded — their
+# label form is unrelated to the new daemon scheme, so they cannot be derived.
+old_launchagent_plists() {
+    local agent="$1"
+    echo "$USER_LAUNCH_AGENTS_DIR/com.openclaw.workspace-git-sync-${agent}.plist"
+    echo "$USER_LAUNCH_AGENTS_DIR/com.openclaw.obsidian-headless-${agent}.plist"
+    echo "$USER_LAUNCH_AGENTS_DIR/com.qmd.watch-${agent}.plist"
+    echo "$USER_LAUNCH_AGENTS_DIR/com.qmd.http-${agent}.plist"
+}
+
+# --- Per-service PATHs (three distinct ones — do NOT collapse) ----------------
+# git-sync: no node needed (the sync script only shells out to git).
+GIT_SYNC_PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+# obsidian-headless: HARD-PIN Node 23.11.0. ob's better-sqlite3 12.6.2 has no
+# Node-26 prebuilt and won't compile on Node 26; resolve_node_bin_dir() would
+# hand back the default Node 26 here, so we must construct the path explicitly.
+OBSIDIAN_NODE_BIN="$HOME_DIR/.local/share/mise/installs/node/23.11.0/bin"
+OBSIDIAN_PATH="${OBSIDIAN_NODE_BIN}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+# qmd-watch + qmd-http: bun first, then mise shims (default Node 26 is fine for
+# qmd — its better-sqlite3 12.10.0 has a Node-26 prebuilt).
+QMD_PATH="$HOME_DIR/.bun/bin:$HOME_DIR/.local/share/mise/shims:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+# --- Programs ----------------------------------------------------------------
+# OB_BIN: the daemon spec says ~/Library/pnpm/bin/ob, but the validated existing
+# setup uses ~/Library/pnpm/ob (no /bin/) — and on this machine only the latter
+# exists. Try the spec path, fall back to the validated path, then PATH; use the
+# first executable. (Discrepancy surfaced in the deploy summary.)
+resolve_ob_bin() {
+    local cand
+    for cand in "$HOME_DIR/Library/pnpm/bin/ob" "$HOME_DIR/Library/pnpm/ob"; do
+        [ -x "$cand" ] && { echo "$cand"; return 0; }
+    done
+    cand="$(command -v ob 2>/dev/null || true)"
+    [ -n "$cand" ] && { echo "$cand"; return 0; }
+    return 1
+}
+QMD_BIN="$HOME_DIR/.bun/bin/qmd"   # PATH already leads with .bun/bin; pin per spec.
+
+# --- Port map: positional over the FULL agent list, then we look up selected --
+# Computing the index within the selected subset would mis-assign ports on a
+# scoped run, so the map is always built over every agent in get_agent_ids order.
+declare -A PORT_MAP
+_port_idx=0
+for _id in $(get_agent_ids); do
+    PORT_MAP["$_id"]=$((QMD_HTTP_BASE_PORT + ACCOUNT_INDEX * 100 + _port_idx))
+    _port_idx=$((_port_idx + 1))
+done
+
+# =============================================================================
+# Plist emitters — each writes a complete plist to stdout.
+# All four carry <UserName>$ACCOUNT</UserName> (the crux of a system daemon
+# running as the user) and absolute ProgramArguments.
+# =============================================================================
+
+emit_git_sync_plist() {
+    local agent="$1" label script
+    label="$(daemon_label git-sync "$agent")"
+    script="$(git_sync_script "$agent")"
+    cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${label}</string>
+    <key>UserName</key>
+    <string>${ACCOUNT}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>${script}</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Minute</key>
+        <integer>30</integer>
+    </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>${GIT_SYNC_PATH}</string>
+        <key>HOME</key>
+        <string>${HOME_DIR}</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>${LOG_DIR}/git-sync-${agent}.log</string>
+    <key>StandardErrorPath</key>
+    <string>${LOG_DIR}/git-sync-${agent}.log</string>
+</dict>
+</plist>
+EOF
+}
+
+emit_obsidian_plist() {
+    local agent="$1" ob_bin="$2" workspace="$3" label
+    label="$(daemon_label obsidian-headless "$agent")"
+    cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${label}</string>
+    <key>UserName</key>
+    <string>${ACCOUNT}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${ob_bin}</string>
+        <string>sync</string>
+        <string>--path</string>
+        <string>${workspace}</string>
+        <string>--continuous</string>
+    </array>
+    <key>KeepAlive</key>
+    <true/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>${OBSIDIAN_PATH}</string>
+        <key>HOME</key>
+        <string>${HOME_DIR}</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>${LOG_DIR}/obsidian-headless-${agent}.log</string>
+    <key>StandardErrorPath</key>
+    <string>${LOG_DIR}/obsidian-headless-${agent}.log</string>
+</dict>
+</plist>
+EOF
+}
+
+emit_qmd_watch_plist() {
+    local agent="$1" script="$2" label
+    label="$(daemon_label qmd-watch "$agent")"
+    # No QMD_CONFIG_DIR/INDEX_PATH here — the watch script self-exports them.
+    cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${label}</string>
+    <key>UserName</key>
+    <string>${ACCOUNT}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>${script}</string>
+    </array>
+    <key>KeepAlive</key>
+    <true/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>${QMD_PATH}</string>
+        <key>HOME</key>
+        <string>${HOME_DIR}</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>${LOG_DIR}/qmd-watch-${agent}.log</string>
+    <key>StandardErrorPath</key>
+    <string>${LOG_DIR}/qmd-watch-${agent}.log</string>
+</dict>
+</plist>
+EOF
+}
+
+emit_qmd_http_plist() {
+    local agent="$1" port="$2" workspace="$3" label
+    label="$(daemon_label qmd-http "$agent")"
+    cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${label}</string>
+    <key>UserName</key>
+    <string>${ACCOUNT}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${QMD_BIN}</string>
+        <string>mcp</string>
+        <string>--http</string>
+        <string>--port</string>
+        <string>${port}</string>
+    </array>
+    <key>KeepAlive</key>
+    <true/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>${QMD_PATH}</string>
+        <key>HOME</key>
+        <string>${HOME_DIR}</string>
+        <key>QMD_CONFIG_DIR</key>
+        <string>${workspace}/.qmd</string>
+        <key>INDEX_PATH</key>
+        <string>${workspace}/.qmd/index.sqlite</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>${LOG_DIR}/qmd-http-${agent}.log</string>
+    <key>StandardErrorPath</key>
+    <string>${LOG_DIR}/qmd-http-${agent}.log</string>
+</dict>
+</plist>
+EOF
+}
+
+# =============================================================================
+# Install / load a single daemon from a temp plist (idempotent).
+#   $1 = label   $2 = path to the generated temp plist
+# install replaces the /Library file atomically; bootout-then-bootstrap reloads.
+# bootout is best-effort (the daemon may not be loaded yet).
+# =============================================================================
+install_daemon() {
+    local label="$1" tmp="$2" dest
+    dest="$SYSTEM_DAEMONS_DIR/${label}.plist"
+    sudo install -o root -g wheel -m 644 "$tmp" "$dest"
+    sudo launchctl bootout "system/${label}" 2>/dev/null || true
+    # bootout is asynchronous; an immediate bootstrap can hit
+    # "Bootstrap failed: 5: Input/output error" on the teardown race. Retry a
+    # few times with a short settle, then warn (don't abort the whole run).
+    for _ in 1 2 3 4 5; do
+        if sudo launchctl bootstrap system "$dest"; then
+            echo "  loaded: ${label}"
+            return 0
+        fi
+        sleep 1
+    done
+    warn "bootstrap failed after retries: ${label} (plist installed; will load at next boot)"
+    return 0
+}
+
+# Best-effort teardown of one old LaunchAgent: bootout from the GUI domain (which
+# may not exist over SSH — hence 2>/dev/null), then rm. The rm is load-bearing:
+# it stops the LaunchAgent from double-running on the next GUI login.
+teardown_old_launchagent() {
+    local plist="$1"
+    [ -f "$plist" ] || return 0
+    launchctl bootout "$GUI_DOMAIN" "$plist" 2>/dev/null || true
+    rm -f "$plist"
+    echo "  removed old LaunchAgent: $(basename "$plist")"
+}
+
+# Idempotently rewrite the qmd-watch agent lock to the per-account form. Anchored
+# on '^AGENT_LOCK=' so re-runs are stable (matching the literal old value would
+# double-namespace: spannagel-spannagel-<agent> on the second pass).
+namespace_qmd_watch_lock() {
+    local script="$1" agent="$2"
+    sed -i '' -E "s|^AGENT_LOCK=.*|AGENT_LOCK=\"/tmp/qmd-watch-${ACCOUNT}-${agent}.lock\"|" "$script"
+}
+
+# =============================================================================
+# --status
+# =============================================================================
+show_status() {
+    sudo_prime
+    echo ""
+    echo "openclaw daemon status — account '${ACCOUNT}' (index ${ACCOUNT_INDEX})"
+    echo "==================================================================="
+    local agent svc label workspace port
+    for agent in $(get_agent_ids); do
+        workspace="$(workspace_dir_for "$agent" "$WORKSPACES_DIR")"
+        port="${PORT_MAP[$agent]}"
+        echo ""
+        echo "--- ${agent} (qmd-http port ${port}) ---"
+        for svc in git-sync obsidian-headless qmd-watch qmd-http; do
+            label="$(daemon_label "$svc" "$agent")"
+            if sudo launchctl print "system/${label}" &>/dev/null; then
+                printf "  %-18s loaded\n" "$svc:"
+            elif [ -f "$(daemon_plist "$svc" "$agent")" ]; then
+                printf "  %-18s installed, not loaded\n" "$svc:"
+            else
+                printf "  %-18s not deployed\n" "$svc:"
+            fi
+        done
+        if [ -f "$workspace/.qmd/index.sqlite" ]; then
+            if curl -sf "http://localhost:${port}/health" &>/dev/null; then
+                echo "  qmd-http health:   responding"
+            else
+                echo "  qmd-http health:   not responding"
+            fi
+        fi
+    done
+    echo ""
+    exit 0
+}
+
+# =============================================================================
+# --uninstall  (scan-based: every system daemon for THIS account, all services)
+# =============================================================================
+uninstall() {
+    sudo_prime
+    log "Uninstalling openclaw system daemons for account '${ACCOUNT}'..."
+    local svc plist label
+    local found=0
+    for svc in git-sync obsidian-headless qmd-watch qmd-http; do
+        # Pin the svc token + account; '.plist' anchors the trailing agent
+        # segment so e.g. a spannagel-account agent named 'tl' is never matched.
+        for plist in "$SYSTEM_DAEMONS_DIR/com.openclaw.${svc}.${ACCOUNT}."*.plist; do
+            [ -f "$plist" ] || continue
+            found=1
+            label="$(basename "$plist" .plist)"
+            sudo launchctl bootout "system/${label}" 2>/dev/null || true
+            sudo rm -f "$plist"
+            echo "  removed: ${label}"
+        done
+    done
+    [ "$found" -eq 0 ] && log "  (no daemons found for this account)"
+    log "Uninstall complete. Workspaces, indexes, and helper scripts were NOT removed."
+    exit 0
+}
+
+# =============================================================================
+# Arg parsing
+# =============================================================================
+case "${1:-}" in
+    --status)    show_status ;;
+    --uninstall) uninstall ;;
+esac
+
+mapfile -t ALL_AGENT_IDS < <(get_agent_ids)
+SELECTED_AGENTS=()
+if [ $# -gt 0 ]; then
+    for arg in "$@"; do
+        case "$arg" in
+            --*) die "Unknown flag '$arg'. Valid: --status, --uninstall" ;;
+        esac
+        found=false
+        for id in "${ALL_AGENT_IDS[@]}"; do
+            [ "$id" = "$arg" ] && { SELECTED_AGENTS+=("$arg"); found=true; break; }
+        done
+        $found || die "Unknown agent '$arg'. Available: ${ALL_AGENT_IDS[*]}"
+    done
+else
+    SELECTED_AGENTS=("${ALL_AGENT_IDS[@]}")
+fi
+
+# =============================================================================
+# Preflight
+# =============================================================================
+OB_BIN="$(resolve_ob_bin || true)"   # may be empty -> obsidian service skipped
+
+# launchd does not create the parent of StandardOutPath; without this the
+# daemons silently fail to spawn.
+mkdir -p "$LOG_DIR"
+
+# Temp dir for generated plists (installed into /Library via `sudo install`).
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-daemons.XXXXXX")"
+cleanup_tmp() { rm -rf "$TMP_DIR"; }
+trap cleanup_tmp EXIT
+
+echo ""
+echo "=========================================="
+echo "  openclaw system-daemon deploy"
+echo "  account:  ${ACCOUNT} (index ${ACCOUNT_INDEX})"
+echo "  agents:   ${SELECTED_AGENTS[*]}"
+echo "  ob bin:   ${OB_BIN:-<not found — obsidian skipped>}"
+echo "=========================================="
+
+# Prime sudo once up front so the per-daemon installs don't each re-prompt.
+sudo_prime
+
+# =============================================================================
+# Per-agent deployment
+# =============================================================================
+for agent in "${SELECTED_AGENTS[@]}"; do
+    workspace="$(workspace_dir_for "$agent" "$WORKSPACES_DIR")"
+    port="${PORT_MAP[$agent]}"
+
+    echo ""
+    log "agent '${agent}'  (workspace: ${workspace}, qmd-http port: ${port})"
+
+    if [ ! -d "$workspace" ]; then
+        warn "workspace missing — skipping all services for '${agent}': ${workspace}"
+        continue
+    fi
+
+    # --- git-sync ------------------------------------------------------------
+    git_script="$(git_sync_script "$agent")"
+    if [ -x "$git_script" ] || [ -f "$git_script" ]; then
+        tmp="$TMP_DIR/$(daemon_label git-sync "$agent").plist"
+        emit_git_sync_plist "$agent" > "$tmp"
+        install_daemon "$(daemon_label git-sync "$agent")" "$tmp"
+    else
+        warn "git-sync skipped for '${agent}': helper missing — $git_script (run setup-mac-workspaces.sh first)"
+    fi
+
+    # --- obsidian-headless ---------------------------------------------------
+    # Gate on three prereqs — a missing one must skip cleanly, not deploy a
+    # crash-looping daemon: (1) ob binary present, (2) Node 23.11.0 installed
+    # (better-sqlite3 12.6.2 has no Node-26 build), (3) the vault is actually
+    # linked for this workspace (else `ob sync --continuous` errors forever).
+    if [ -z "${OB_BIN:-}" ]; then
+        warn "obsidian-headless skipped for '${agent}': ob binary not found (install @nicekiwi/obsidian-headless)"
+    elif [ ! -d "$OBSIDIAN_NODE_BIN" ]; then
+        warn "obsidian-headless skipped for '${agent}': Node 23.11.0 not installed ($OBSIDIAN_NODE_BIN)"
+    elif ! PATH="$OBSIDIAN_PATH" "$OB_BIN" sync-status --path "$workspace" &>/dev/null; then
+        warn "obsidian-headless skipped for '${agent}': vault not linked for $workspace (run setup-mac-workspaces.sh first)"
+    else
+        tmp="$TMP_DIR/$(daemon_label obsidian-headless "$agent").plist"
+        emit_obsidian_plist "$agent" "$OB_BIN" "$workspace" > "$tmp"
+        install_daemon "$(daemon_label obsidian-headless "$agent")" "$tmp"
+    fi
+
+    # --- qmd-watch -----------------------------------------------------------
+    # Prereqs: the installed watch script AND a .qmd index dir. We also rewrite
+    # the script's agent lock to the per-account form (idempotent).
+    watch_script="$(qmd_watch_script "$agent")"
+    if [ ! -f "$watch_script" ]; then
+        warn "qmd-watch skipped for '${agent}': helper missing — $watch_script (run setup-mac-qmd.sh first)"
+    elif [ ! -d "$workspace/.qmd" ]; then
+        warn "qmd-watch skipped for '${agent}': no index dir — $workspace/.qmd (run setup-mac-qmd.sh first)"
+    else
+        namespace_qmd_watch_lock "$watch_script" "$agent"
+        tmp="$TMP_DIR/$(daemon_label qmd-watch "$agent").plist"
+        emit_qmd_watch_plist "$agent" "$watch_script" > "$tmp"
+        install_daemon "$(daemon_label qmd-watch "$agent")" "$tmp"
+    fi
+
+    # --- qmd-http ------------------------------------------------------------
+    # Prereq: a built index. The qmd binary itself is pinned to ~/.bun/bin/qmd.
+    if [ ! -f "$workspace/.qmd/index.sqlite" ]; then
+        warn "qmd-http skipped for '${agent}': no index — $workspace/.qmd/index.sqlite (run setup-mac-qmd.sh first)"
+    elif [ ! -x "$QMD_BIN" ]; then
+        warn "qmd-http skipped for '${agent}': qmd binary not found at $QMD_BIN (bun install -g @tobilu/qmd)"
+    else
+        tmp="$TMP_DIR/$(daemon_label qmd-http "$agent").plist"
+        emit_qmd_http_plist "$agent" "$port" "$workspace" > "$tmp"
+        install_daemon "$(daemon_label qmd-http "$agent")" "$tmp"
+    fi
+
+    # --- tear down the superseded per-user LaunchAgents ----------------------
+    # Do this AFTER the daemons are up so there's no service gap. Best-effort
+    # bootout (gui domain may not exist over SSH); the rm is what matters.
+    while IFS= read -r old_plist; do
+        teardown_old_launchagent "$old_plist"
+    done < <(old_launchagent_plists "$agent")
+done
+
+echo ""
+echo "=========================================="
+echo "  Deploy complete — account '${ACCOUNT}'"
+echo "=========================================="
+echo ""
+echo "qmd-http ports:"
+for agent in "${SELECTED_AGENTS[@]}"; do
+    echo "  ${agent}: http://localhost:${PORT_MAP[$agent]}/mcp"
+done
+echo ""
+echo "Status:    $0 --status"
+echo "Logs:      ${LOG_DIR}/{git-sync,obsidian-headless,qmd-watch,qmd-http}-<agent>.log"
+echo "Uninstall: $0 --uninstall"

--- a/scripts/setup-mac-qmd.sh
+++ b/scripts/setup-mac-qmd.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
-# Setup local qmd semantic search for Mac workspaces.
+# Build local qmd semantic-search indexes for Mac workspaces. PREP ONLY —
+# installs no services.
 #
-# Mirrors the VPS qmd Ansible role: per-workspace watcher + HTTP daemon.
-# Each workspace gets:
-#   - .qmd/ directory with collections config
-#   - fswatch-based watcher (LaunchAgent) for live index updates
-#   - HTTP daemon (LaunchAgent) serving MCP endpoint
+# Per selected agent, this does the one-time setup the qmd daemons depend on:
+#   - .qmd/ directory with collections config + initial index/embeddings
 #   - Text extraction (PDFs, images, .docx, .xlsx) via .scripts/extract
+#   - Install ~/.local/bin/qmd-watch-<agent>.sh (the helper the watch daemon runs)
+#
+# The qmd-watch + qmd-http daemons are deployed separately by
+# deploy-mac-daemons.sh as login-independent system LaunchDaemons (it also owns
+# the per-account HTTP port assignment). Splitting prep from the service layer
+# means running this for prep can never double-run a daemon on one sqlite index.
 #
 # Agent list is read from ansible/group_vars/openclaw.yml (single source of truth).
-# Port assignment is positional over all agents (matches VPS convention).
 #
 # Prerequisites:
 #   - yq + jq installed (brew install yq jq)
@@ -18,12 +21,13 @@
 #   - fswatch installed (brew install fswatch)
 #
 # Usage:
-#   ./scripts/setup-mac-qmd.sh                    # Full setup (all agents)
-#   ./scripts/setup-mac-qmd.sh main tl             # Specific agents only
-#   ./scripts/setup-mac-qmd.sh --uninstall         # Remove LaunchAgents + scripts
-#   ./scripts/setup-mac-qmd.sh --status            # Show service status
+#   ./scripts/setup-mac-qmd.sh                    # prep all agents
+#   ./scripts/setup-mac-qmd.sh main tl             # prep specific agents
+#   ./scripts/setup-mac-qmd.sh --uninstall         # remove qmd-watch helper scripts
+#   ./scripts/setup-mac-qmd.sh --status            # show index status
 #
 # Re-running is safe (idempotent). Existing indexes are preserved.
+# Deploy/teardown of the daemons themselves: deploy-mac-daemons.sh.
 
 set -euo pipefail
 
@@ -36,9 +40,6 @@ BIN_DIR="$HOME/.local/bin"
 LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
 LOG_DIR="$HOME/Library/Logs/openclaw"
 GUI_DOMAIN="gui/$(id -u)"
-
-# Port assignment: positional starting at 8191 (mirrors VPS qmd_http_base_port)
-QMD_HTTP_BASE_PORT=8191
 
 # --- Helpers ---
 
@@ -59,14 +60,6 @@ bootout_if_loaded() {
         launchctl bootout "$GUI_DOMAIN" "$plist" 2>/dev/null || true
     fi
 }
-
-# Build port map (positional over ALL agents, ensures consistency with VPS)
-declare -A PORT_MAP
-_port=$QMD_HTTP_BASE_PORT
-for _id in $(get_agent_ids); do
-    PORT_MAP["$_id"]=$_port
-    _port=$((_port + 1))
-done
 
 # --- Uninstall (scan-based: finds all matching services regardless of current config) ---
 
@@ -92,37 +85,13 @@ uninstall() {
 
 show_status() {
     echo ""
-    echo "qmd Service Status"
-    echo "==================="
+    echo "qmd Index Status (prep artifacts only)"
+    echo "Daemon status lives in: deploy-mac-daemons.sh --status"
+    echo "======================================================="
     for agent_id in $(get_agent_ids); do
-        local agent_port="${PORT_MAP[$agent_id]}"
         local workspace_dir="$(workspace_dir_for "$agent_id" "$WORKSPACES_DIR")"
         echo ""
-        echo "--- $agent_id (port $agent_port) ---"
-
-        # Watcher
-        local watch_label
-        watch_label="$(plist_id_watch "$agent_id")"
-        if launchctl list "$watch_label" &>/dev/null; then
-            local pid
-            pid=$(launchctl list "$watch_label" 2>/dev/null | grep '"PID"' | tr -cd '0-9')
-            echo "  Watcher: running${pid:+ (pid: $pid)}"
-        else
-            echo "  Watcher: not running"
-        fi
-
-        # HTTP daemon
-        local http_label
-        http_label="$(plist_id_http "$agent_id")"
-        if launchctl list "$http_label" &>/dev/null; then
-            if curl -sf "http://localhost:$agent_port/health" &>/dev/null; then
-                echo "  HTTP:    running (http://localhost:$agent_port/mcp)"
-            else
-                echo "  HTTP:    loaded but not responding"
-            fi
-        else
-            echo "  HTTP:    not running"
-        fi
+        echo "--- $agent_id ---"
 
         # Index stats
         if [ -f "$workspace_dir/.qmd/index.sqlite" ]; then
@@ -136,6 +105,13 @@ show_status() {
             )
         else
             echo "  Index:   not created"
+        fi
+
+        # Watch helper script
+        if [ -f "$(watch_script_path "$agent_id")" ]; then
+            echo "  Watcher helper: installed"
+        else
+            echo "  Watcher helper: not installed"
         fi
     done
     echo ""
@@ -323,189 +299,18 @@ done
 echo ""
 
 # ============================================================
-# STEP 3: Create LaunchAgent plists
+# Summary
 # ============================================================
 
-log "Step 3: Create LaunchAgents"
-
-QMD_BIN="$(command -v qmd || echo "$HOME/.bun/bin/qmd")"
-QMD_NODE_BIN_DIR="$(resolve_node_bin_dir)"
-QMD_LAUNCHAGENT_PATH="$HOME/.bun/bin:${QMD_NODE_BIN_DIR}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
-
-for agent_id in "${SELECTED_AGENTS[@]}"; do
-    workspace_dir="$(workspace_dir_for "$agent_id" "$WORKSPACES_DIR")"
-    agent_port="${PORT_MAP[$agent_id]}"
-
-    if [ ! -d "$workspace_dir" ]; then
-        continue
-    fi
-
-    echo "  --- $agent_id (port $agent_port) ---"
-
-    # Watcher LaunchAgent
-    plist_watch="$(plist_path_watch "$agent_id")"
-    label_watch="$(plist_id_watch "$agent_id")"
-    script_path="$(watch_script_path "$agent_id")"
-
-    cat > "$plist_watch" <<EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>${label_watch}</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>/bin/bash</string>
-        <string>${script_path}</string>
-    </array>
-    <key>KeepAlive</key>
-    <true/>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>PATH</key>
-        <string>${QMD_LAUNCHAGENT_PATH}</string>
-        <key>HOME</key>
-        <string>${HOME}</string>
-    </dict>
-    <key>StandardOutPath</key>
-    <string>${LOG_DIR}/qmd-watch-${agent_id}.log</string>
-    <key>StandardErrorPath</key>
-    <string>${LOG_DIR}/qmd-watch-${agent_id}.log</string>
-    <key>ThrottleInterval</key>
-    <integer>30</integer>
-</dict>
-</plist>
-EOF
-    echo "  Installed: $plist_watch"
-
-    # HTTP daemon LaunchAgent
-    plist_http="$(plist_path_http "$agent_id")"
-    label_http="$(plist_id_http "$agent_id")"
-
-    cat > "$plist_http" <<EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>${label_http}</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>${QMD_BIN}</string>
-        <string>mcp</string>
-        <string>--http</string>
-        <string>--port</string>
-        <string>${agent_port}</string>
-    </array>
-    <key>KeepAlive</key>
-    <true/>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>PATH</key>
-        <string>${QMD_LAUNCHAGENT_PATH}</string>
-        <key>HOME</key>
-        <string>${HOME}</string>
-        <key>QMD_CONFIG_DIR</key>
-        <string>${workspace_dir}/.qmd</string>
-        <key>INDEX_PATH</key>
-        <string>${workspace_dir}/.qmd/index.sqlite</string>
-    </dict>
-    <key>StandardOutPath</key>
-    <string>${LOG_DIR}/qmd-http-${agent_id}.log</string>
-    <key>StandardErrorPath</key>
-    <string>${LOG_DIR}/qmd-http-${agent_id}.log</string>
-    <key>ThrottleInterval</key>
-    <integer>30</integer>
-</dict>
-</plist>
-EOF
-    echo "  Installed: $plist_http"
-done
-
-echo ""
-
-# ============================================================
-# STEP 4: Load LaunchAgents
-# ============================================================
-
-log "Step 4: Loading LaunchAgents"
-
-for agent_id in "${SELECTED_AGENTS[@]}"; do
-    workspace_dir="$(workspace_dir_for "$agent_id" "$WORKSPACES_DIR")"
-
-    if [ ! -d "$workspace_dir" ]; then
-        continue
-    fi
-
-    # Watcher
-    plist_watch="$(plist_path_watch "$agent_id")"
-    if [ -f "$plist_watch" ]; then
-        bootout_if_loaded "$plist_watch"
-        launchctl bootstrap "$GUI_DOMAIN" "$plist_watch"
-        echo "  Loaded: $(plist_id_watch "$agent_id")"
-    fi
-
-    # HTTP daemon
-    plist_http="$(plist_path_http "$agent_id")"
-    if [ -f "$plist_http" ]; then
-        bootout_if_loaded "$plist_http"
-        launchctl bootstrap "$GUI_DOMAIN" "$plist_http"
-        echo "  Loaded: $(plist_id_http "$agent_id")"
-    fi
-done
-
-echo ""
-
-# ============================================================
-# STEP 5: Verify
-# ============================================================
-
-log "Step 5: Verify"
-
-sleep 2  # give daemons a moment to start
-
-ALL_OK=true
-for agent_id in "${SELECTED_AGENTS[@]}"; do
-    agent_port="${PORT_MAP[$agent_id]}"
-
-    echo "  --- $agent_id ---"
-
-    # Check watcher
-    if launchctl list "$(plist_id_watch "$agent_id")" &>/dev/null; then
-        echo "  Watcher: OK"
-    else
-        warn "  Watcher: FAILED to start"
-        ALL_OK=false
-    fi
-
-    # Check HTTP daemon
-    if curl -sf "http://localhost:$agent_port/health" &>/dev/null; then
-        echo "  HTTP:    OK (http://localhost:$agent_port/mcp)"
-    else
-        echo "  HTTP:    starting... (may take a few seconds for first model load)"
-    fi
-done
-
-echo ""
 echo "=========================================="
-echo "  Setup complete!"
+echo "  qmd prep complete! (${#SELECTED_AGENTS[@]} agents)"
 echo "=========================================="
 echo ""
-echo "Ports:"
-for agent_id in "${SELECTED_AGENTS[@]}"; do
-    echo "  ${agent_id}: http://localhost:${PORT_MAP[$agent_id]}/mcp"
-done
+echo "This installed no services. Deploy the qmd daemons (and their per-account"
+echo "HTTP ports) with:"
+echo "  ./scripts/deploy-mac-daemons.sh ${SELECTED_AGENTS[*]}"
 echo ""
-echo "Status:   $0 --status"
-echo "Logs:     $LOG_DIR/qmd-{watch,http}-*.log"
+echo "Status:    $0 --status                       # index status (this script)"
+echo "           ./scripts/deploy-mac-daemons.sh --status   # daemon status"
+echo "Logs:      $LOG_DIR/qmd-{watch,http}-*.log"
 echo "Uninstall: $0 --uninstall"
-echo ""
-if ! $ALL_OK; then
-    echo "Some services failed to start. Check logs for details."
-    exit 1
-fi

--- a/scripts/setup-mac-qmd.sh
+++ b/scripts/setup-mac-qmd.sh
@@ -30,7 +30,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/agents.sh"
 
-WORKSPACES_DIR="$HOME/code/personal/workspaces"
+WORKSPACES_DIR="$HOME/dev/personal/workspaces"
 WATCH_TEMPLATE="$SCRIPT_DIR/templates/qmd-watch-mac.sh.tmpl"
 BIN_DIR="$HOME/.local/bin"
 LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"

--- a/scripts/setup-mac-workspaces.sh
+++ b/scripts/setup-mac-workspaces.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
-# Setup Mac workspace sync: git backup (hourly) + Obsidian Headless (continuous).
+# Prepare Mac agent workspaces for sync. PREP ONLY — installs no services.
 #
-# Mirrors the VPS sync setup for all agent workspaces on the Mac:
-#   - Git sync scripts + LaunchAgents (hourly at :30, staggered from VPS at :00)
-#   - Obsidian Headless vault linking + LaunchAgents (continuous sync)
+# Per selected agent, this does the one-time setup the daemons depend on:
+#   - Git repo setup (.gitignore, SSH remote, create + push if absent)
+#   - Install ~/.local/bin/workspace-git-sync-<agent>.sh (the helper the daemon runs)
+#   - Obsidian Headless vault linking (+ exclusions + initial sync)
+#
+# The four per-agent daemons (git-sync, obsidian-headless, qmd-watch, qmd-http)
+# are deployed separately by deploy-mac-daemons.sh as login-independent system
+# LaunchDaemons. Splitting prep from the service layer lets that one deployer own
+# launchctl for every account, so running this for prep can never double-run a daemon.
 #
 # Agent list is read from ansible/group_vars/openclaw.yml (single source of truth).
 # Workspace dir convention: <agent_id>-workspace
@@ -17,10 +23,12 @@
 #   - ~/.obsidian-headless/auth_token exists (ob login)
 #
 # Usage:
-#   ./scripts/setup-mac-workspaces.sh              # Full setup
-#   ./scripts/setup-mac-workspaces.sh --uninstall   # Remove all LaunchAgents + scripts
+#   ./scripts/setup-mac-workspaces.sh                 # prep all agents
+#   ./scripts/setup-mac-workspaces.sh main tl          # prep specific agents
+#   ./scripts/setup-mac-workspaces.sh --uninstall      # remove git-sync helper scripts
 #
 # Re-running is safe (idempotent). Each step checks existing state before acting.
+# Deploy/teardown of the daemons themselves: deploy-mac-daemons.sh.
 
 set -euo pipefail
 
@@ -33,14 +41,12 @@ SYNC_TEMPLATE="$SCRIPT_DIR/templates/workspace-git-sync-mac.sh.tmpl"
 SYNC_BIN_DIR="$HOME/.local/bin"
 LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
 OB_BIN="$HOME/Library/pnpm/ob"
+# ob's native better-sqlite3 (12.6.2) is ABI-locked to Node 23.11.0; pin it so ob
+# works regardless of the default node (which may be 26). Mirrors deploy-mac-daemons.sh.
+OB_NODE_BIN="$HOME/.local/share/mise/installs/node/23.11.0/bin"
 GITHUB_ORG="pandysp"
 GUI_DOMAIN="gui/$(id -u)"
 INITIAL_SYNC_TIMEOUT=120
-
-# Resolve node bin dir for LaunchAgents (they don't inherit shell PATH) — see
-# resolve_node_bin_dir in lib/agents.sh (prefers the active mise/nvm node).
-NODE_BIN_DIR="$(resolve_node_bin_dir)"
-LAUNCHAGENT_PATH="${NODE_BIN_DIR}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
 # Excluded folders for Obsidian Sync — must match VPS deployment
 OBSIDIAN_EXCLUDED_FOLDERS=".git,.venv,.packages,.npm-packages,.bin,.cache,.local,.npm,.qmd,.scripts,.claude,.ralph,.env,.beads,.config,.dev,.dolt,.openclaw,.pi,.repos,.state,node_modules,repos,claude-code-mcp,reranker-bench,obsidian,migration"
@@ -49,6 +55,15 @@ OBSIDIAN_EXCLUDED_FOLDERS=".git,.venv,.packages,.npm-packages,.bin,.cache,.local
 
 log() { echo "==> $*"; }
 warn() { echo "WARNING: $*" >&2; }
+
+# Run ob under the pinned Node — its native better-sqlite3 won't load otherwise.
+ob_run() {
+    if [ -d "$OB_NODE_BIN" ]; then
+        PATH="$OB_NODE_BIN:$PATH" "$OB_BIN" "$@"
+    else
+        "$OB_BIN" "$@"
+    fi
+}
 
 plist_id_git() { echo "com.openclaw.workspace-git-sync-$1"; }
 plist_id_ob()  { echo "com.openclaw.obsidian-headless-$1"; }
@@ -149,11 +164,24 @@ else
     fi
 fi
 
-AGENT_IDS=($(get_agent_ids))
+# Resolve selected agents (positional args filter the full list; none = all).
+ALL_AGENT_IDS=($(get_agent_ids))
+AGENT_IDS=()
+if [ $# -gt 0 ]; then
+    for arg in "$@"; do
+        found=false
+        for id in "${ALL_AGENT_IDS[@]}"; do
+            [ "$id" = "$arg" ] && { AGENT_IDS+=("$arg"); found=true; break; }
+        done
+        $found || { echo "ERROR: Unknown agent '$arg'. Available: ${ALL_AGENT_IDS[*]}"; exit 1; }
+    done
+else
+    AGENT_IDS=("${ALL_AGENT_IDS[@]}")
+fi
 
 echo ""
 echo "=========================================="
-echo "  Mac Workspace Sync Setup"
+echo "  Mac Workspace Prep (no services)"
 echo "  Agents: ${AGENT_IDS[*]}"
 echo "=========================================="
 echo ""
@@ -240,10 +268,10 @@ done
 echo ""
 
 # ============================================================
-# STEP 2: Git sync scripts + LaunchAgents
+# STEP 2: Git sync helper scripts
 # ============================================================
 
-log "Step 2: Git sync scripts + LaunchAgents (hourly at :30)"
+log "Step 2: Git sync helper scripts"
 
 for agent_id in "${AGENT_IDS[@]}"; do
     workspace_dir="$(workspace_dir_for "$agent_id" "$WORKSPACES_DIR")"
@@ -263,45 +291,6 @@ for agent_id in "${AGENT_IDS[@]}"; do
         "$SYNC_TEMPLATE" > "$script_path"
     chmod +x "$script_path"
     echo "  Installed: $script_path"
-
-    # Create LaunchAgent plist
-    plist="$(plist_path_git "$agent_id")"
-    label="$(plist_id_git "$agent_id")"
-    log_dir="$HOME/Library/Logs/openclaw"
-    mkdir -p "$log_dir"
-
-    cat > "$plist" <<EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>${label}</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>/bin/bash</string>
-        <string>${script_path}</string>
-    </array>
-    <key>StartCalendarInterval</key>
-    <dict>
-        <key>Minute</key>
-        <integer>30</integer>
-    </dict>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>PATH</key>
-        <string>${LAUNCHAGENT_PATH}</string>
-        <key>HOME</key>
-        <string>${HOME}</string>
-    </dict>
-    <key>StandardOutPath</key>
-    <string>${log_dir}/git-sync-${agent_id}.log</string>
-    <key>StandardErrorPath</key>
-    <string>${log_dir}/git-sync-${agent_id}.log</string>
-</dict>
-</plist>
-EOF
-    echo "  Installed: $plist"
 done
 
 echo ""
@@ -324,13 +313,13 @@ for agent_id in "${AGENT_IDS[@]}"; do
     echo "  --- $agent_id ---"
 
     # Check if already linked
-    if "$OB_BIN" sync-status --path "$workspace_dir" &>/dev/null; then
+    if ob_run sync-status --path "$workspace_dir" &>/dev/null; then
         echo "  Already linked to Obsidian Sync"
         continue
     fi
 
     # Find vault ID by name
-    vault_id=$("$OB_BIN" sync-list-remote 2>&1 | grep "$vault_name" | awk '{print $1}' || true)
+    vault_id=$(ob_run sync-list-remote 2>&1 | grep "$vault_name" | awk '{print $1}' || true)
     if [ -z "$vault_id" ]; then
         warn "Remote vault '$vault_name' not found — skipping. Create it on VPS first."
         continue
@@ -338,20 +327,20 @@ for agent_id in "${AGENT_IDS[@]}"; do
 
     echo "  Linking vault $vault_name (ID: $vault_id)..."
 
-    "$OB_BIN" sync-setup \
+    ob_run sync-setup \
         --vault "$vault_id" \
         --path "$workspace_dir" \
         --password "$VAULT_PASSWORD" \
         --device-name "mac-${agent_id}"
 
     echo "  Configuring exclusions..."
-    "$OB_BIN" sync-config \
+    ob_run sync-config \
         --path "$workspace_dir" \
         --excluded-folders "$OBSIDIAN_EXCLUDED_FOLDERS"
 
     echo "  Running initial sync (timeout: ${INITIAL_SYNC_TIMEOUT}s)..."
     # macOS has no `timeout` command — use background + sleep + kill
-    "$OB_BIN" sync --path "$workspace_dir" &
+    ob_run sync --path "$workspace_dir" &
     OB_PID=$!
     (
         sleep "$INITIAL_SYNC_TIMEOUT"
@@ -367,104 +356,21 @@ done
 echo ""
 
 # ============================================================
-# STEP 4: Obsidian Headless LaunchAgents
-# ============================================================
-
-log "Step 4: Obsidian Headless LaunchAgents (continuous sync)"
-
-for agent_id in "${AGENT_IDS[@]}"; do
-    workspace_dir="$(workspace_dir_for "$agent_id" "$WORKSPACES_DIR")"
-
-    if [ ! -d "$workspace_dir" ]; then
-        warn "Workspace missing: $workspace_dir — skipping"
-        continue
-    fi
-
-    echo "  --- $agent_id ---"
-
-    plist="$(plist_path_ob "$agent_id")"
-    label="$(plist_id_ob "$agent_id")"
-    log_dir="$HOME/Library/Logs/openclaw"
-    mkdir -p "$log_dir"
-
-    cat > "$plist" <<EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>${label}</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>${OB_BIN}</string>
-        <string>sync</string>
-        <string>--path</string>
-        <string>${workspace_dir}</string>
-        <string>--continuous</string>
-    </array>
-    <key>KeepAlive</key>
-    <true/>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>PATH</key>
-        <string>${LAUNCHAGENT_PATH}</string>
-        <key>HOME</key>
-        <string>${HOME}</string>
-    </dict>
-    <key>StandardOutPath</key>
-    <string>${log_dir}/obsidian-headless-${agent_id}.log</string>
-    <key>StandardErrorPath</key>
-    <string>${log_dir}/obsidian-headless-${agent_id}.log</string>
-</dict>
-</plist>
-EOF
-    echo "  Installed: $plist"
-done
-
-echo ""
-
-# ============================================================
-# STEP 5: Load LaunchAgents
-# ============================================================
-
-log "Step 5: Loading LaunchAgents"
-
-for agent_id in "${AGENT_IDS[@]}"; do
-    # Git sync agent
-    plist_git="$(plist_path_git "$agent_id")"
-    if [ -f "$plist_git" ]; then
-        bootout_if_loaded "$plist_git"
-        launchctl bootstrap "$GUI_DOMAIN" "$plist_git"
-        echo "  Loaded: $(plist_id_git "$agent_id")"
-    fi
-
-    # Obsidian headless agent
-    plist_ob="$(plist_path_ob "$agent_id")"
-    if [ -f "$plist_ob" ]; then
-        bootout_if_loaded "$plist_ob"
-        launchctl bootstrap "$GUI_DOMAIN" "$plist_ob"
-        echo "  Loaded: $(plist_id_ob "$agent_id")"
-    fi
-done
-
-echo ""
-
-# ============================================================
 # Summary
 # ============================================================
 
 agent_count=${#AGENT_IDS[@]}
 echo "=========================================="
-echo "  Setup complete! ($agent_count agents)"
+echo "  Prep complete! ($agent_count agents)"
 echo "=========================================="
 echo ""
+echo "This installed no services. Deploy the daemons with:"
+echo "  ./scripts/deploy-mac-daemons.sh ${AGENT_IDS[*]}"
+echo ""
 echo "Verification:"
-echo "  launchctl list | grep openclaw    # Should show $((agent_count * 2)) agents"
-echo "  ob sync-status --path .../<id>-workspace   # Check vault link"
+echo "  ob sync-status --path <workspace>           # Check vault link"
 echo "  ~/.local/bin/workspace-git-sync-<id>.sh     # Manual git sync test"
 echo ""
 echo "Logs: ~/Library/Logs/openclaw/"
 echo ""
-echo "To uninstall: $0 --uninstall"
+echo "To remove git-sync helper scripts: $0 --uninstall"

--- a/scripts/setup-mac-workspaces.sh
+++ b/scripts/setup-mac-workspaces.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/agents.sh"
 
-WORKSPACES_DIR="$HOME/code/personal/workspaces"
+WORKSPACES_DIR="$HOME/dev/personal/workspaces"
 GITIGNORE_SRC="$SCRIPT_DIR/../ansible/roles/workspace/files/gitignore-workspace"
 SYNC_TEMPLATE="$SCRIPT_DIR/templates/workspace-git-sync-mac.sh.tmpl"
 SYNC_BIN_DIR="$HOME/.local/bin"


### PR DESCRIPTION
Replaces the GUI-bound LaunchAgent generators with login-independent system LaunchDaemons so workspace services run on a shared Mac regardless of GUI session, and run for every account.

- `deploy-mac-daemons.sh` — per-account-namespaced daemons (labels, qmd-http ports, watch locks); idempotent; `--status`/`--uninstall`; SSH-friendly via SUDO_ASKPASS; tears down superseded LaunchAgents.
- `setup-mac-{workspaces,qmd}.sh` → prep-only (repo/vault/index + helper scripts), so prep can't double-run a daemon on one sqlite index. Workspaces gen pins Node 23.11.0 for ob.
- `docs/mac-daemon-audit.md` — remediation plan + rollout checklist.

Live: Air (andreasspannagel) fully deployed, 8/9 agents (volki blocked by invalid-UTF-8 filenames). Studio accounts pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)