### PR TITLE
mac workspace sync: fix ob resolution + pin bot identity for backups

### DIFF
--- a/scripts/setup-mac-workspaces.sh
+++ b/scripts/setup-mac-workspaces.sh
@@ -40,7 +40,14 @@ GITIGNORE_SRC="$SCRIPT_DIR/../ansible/roles/workspace/files/gitignore-workspace"
 SYNC_TEMPLATE="$SCRIPT_DIR/templates/workspace-git-sync-mac.sh.tmpl"
 SYNC_BIN_DIR="$HOME/.local/bin"
 LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
-OB_BIN="$HOME/Library/pnpm/ob"
+# Resolve ob: validated path (no /bin/) and spec path (/bin/) differ per machine
+# (Studio: bin/ob; Air: pnpm/ob). Running ob via a symlink breaks its module
+# resolution, so we must point at the REAL binary. Mirrors deploy resolve_ob_bin.
+OB_BIN=""
+for _ob in "$HOME/Library/pnpm/bin/ob" "$HOME/Library/pnpm/ob"; do
+    [ -x "$_ob" ] && { OB_BIN="$_ob"; break; }
+done
+[ -n "$OB_BIN" ] || OB_BIN="$(command -v ob || true)"
 # ob's native better-sqlite3 (12.6.2) is ABI-locked to Node 23.11.0; pin it so ob
 # works regardless of the default node (which may be 26). Mirrors deploy-mac-daemons.sh.
 OB_NODE_BIN="$HOME/.local/share/mise/installs/node/23.11.0/bin"

--- a/scripts/templates/workspace-git-sync-mac.sh.tmpl
+++ b/scripts/templates/workspace-git-sync-mac.sh.tmpl
@@ -14,6 +14,11 @@ fi
 # Suppress errors when there are no tracked-but-ignored files (the common case).
 git ls-files -ci --exclude-standard -z | xargs -0 git rm --cached 2>/dev/null || true
 
+# Pin a non-account identity so backup commits never land on a human's GitHub
+# contribution graph (mirrors the VPS ansible; @localhost is unroutable = UNLINKED).
+git config --local user.name  "OpenClaw Agent (__AGENT_ID__)"
+git config --local user.email "openclaw-__AGENT_ID__@localhost"
+
 # Commit any local changes first (so they're never lost)
 git add -A
 if ! git diff --cached --quiet; then


### PR DESCRIPTION
## What
Two fixes to the Mac workspace-sync tooling, surfaced while rolling out full-parity daemons across all three accounts.

1. **`OB_BIN` resolution** (`setup-mac-workspaces.sh`) — was hardcoded to `~/Library/pnpm/ob`, which only exists on the Air. On the Studio `ob` is at `~/Library/pnpm/bin/ob`, and invoking it via a symlink breaks ob's module resolution (silently returns 0 vaults → prep skips all obsidian linking). Now resolves the real binary across both layouts, mirroring `deploy-mac-daemons.sh:resolve_ob_bin`.

2. **Self-healing bot identity** (`workspace-git-sync-mac.sh.tmpl`) — auto-sync commits fell through to the global git identity (`spannagel.andreas@gmail.com`), landing backup commits on a human's GitHub contribution graph. The script now sets a repo-local `openclaw-<agent>@localhost` identity before every commit (mirrors the VPS ansible; unroutable = UNLINKED = uncounted), self-healing on fresh clones.

## Why
The Studio's two accounts had drifted onto a mixed old/new daemon scheme, and every Mac account's auto-sync was polluting the contribution graph. This encodes the identity fix (applied live during the rollout) so re-provisioning can't reintroduce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)