### PR TITLE
mac: nest policy under `mac:` + gate daemons per agent

### DIFF
--- a/ansible/group_vars/openclaw.yml.example
+++ b/ansible/group_vars/openclaw.yml.example
@@ -112,28 +112,57 @@
 # obsidian_headless_excluded_folders: ".git,.venv,node_modules,.cache,.env,.claude"
 
 # --- Mac local daemons (scripts/deploy-mac-daemons.sh) ---
-# Applies ONLY to the macOS LaunchDaemon deployer + prep scripts (scripts/*mac*.sh),
-# not the Linux/systemd VPS. Path & toolchain tunables live in scripts/lib/mac-config.sh
-# (env-overridable defaults); these two keys are the per-deployment POLICY.
+# NOT ON A MAC? SKIP THIS WHOLE BLOCK. It configures the macOS LaunchDaemon
+# deployer + prep scripts (scripts/*mac*.sh) and nothing else — the Linux/systemd
+# VPS never reads it. Everything Mac-shaped is nested under the single `mac:` key
+# so it stays one skippable block no matter how many knobs get added later.
 #
-# mac_daemons — which of the four per-agent services to run. A service is enabled
-# unless set false (omit a service, or the whole block, to keep it enabled). The
-# deployer reconciles: a service set false is booted out + removed on the next run.
-# mac_daemons:
-#   git-sync: true
-#   obsidian-headless: true
-#   qmd-watch: true
-#   qmd-http: false          # e.g. disable the qmd MCP HTTP server if nothing consumes it
+# Path & toolchain tunables (workspace dir, Node pin, GitHub org, qmd binary) are
+# NOT here — they live in scripts/lib/mac-config.sh as env-overridable defaults.
+# This block is per-deployment POLICY only.
 #
-# mac_accounts — account order for qmd-http port bases. Effective port =
-# QMD_HTTP_BASE_PORT + (index in this list)*100 + agentPosition. List every macOS
-# account that runs these daemons so ports never collide across accounts. Only
-# relevant when qmd-http is enabled on more than one account; OPENCLAW_ACCOUNT_INDEX
-# overrides per run, and an unlisted account falls back to index 0.
-# mac_accounts:
-#   - spannagel
-#   - tl
-#   - andreasspannagel
+# All three sub-keys are optional and fail permissive: omit one, or the whole
+# `mac:` block, and nothing is restricted. A broken or empty config can never
+# silently tear the fleet down.
+#
+# mac:
+#   # agents — which agents get daemons ON THIS MAC. Absent or empty ⇒ every
+#   # agent in openclaw_agents. Use it when the VPS runs the full roster but the
+#   # Mac should only carry a few (each agent costs ~3 resident processes per
+#   # account). Agents dropped from this list are booted out + removed on the
+#   # next full deploy; an explicit `deploy-mac-daemons.sh <agent>` still
+#   # overrides it for a one-off run and reconciles nothing.
+#   #
+#   # NOTE the deliberate asymmetry with obsidian_headless_agents above, which
+#   # means "nobody" when empty: that key opts INTO an optional feature, whereas
+#   # this one RESTRICTS an already-running set, so the safe default is inverted.
+#   agents:
+#     - main
+#     - tl
+#
+#   # daemons — which of the four per-agent services to run. A service is enabled
+#   # unless set false (omit a service, or the block, to keep it enabled). The
+#   # deployer reconciles: a service set false is booted out + removed next run.
+#   daemons:
+#     git-sync: true
+#     obsidian-headless: true
+#     qmd-watch: true
+#     qmd-http: false        # e.g. disable the qmd MCP HTTP server if nothing consumes it
+#
+#   # accounts — account order for qmd-http port bases. Effective port =
+#   # QMD_HTTP_BASE_PORT + (index in this list)*100 + agentPosition. List every
+#   # macOS account running these daemons so ports never collide. Only relevant
+#   # when qmd-http is enabled on more than one account; OPENCLAW_ACCOUNT_INDEX
+#   # overrides per run, and an unlisted account falls back to index 0.
+#   accounts:
+#     - spannagel
+#     - tl
+#     - andreasspannagel
+#
+# DEPRECATED: the pre-nesting flat keys `mac_daemons:` and `mac_accounts:` are
+# still honoured (they map to mac.daemons / mac.accounts) so existing forks keep
+# working, but the deployer prints a migration note. There is no flat equivalent
+# of mac.agents — nest the block to use it.
 
 # --- Claude Code plugins (optional) ---
 # Plugins installed into the VPS agents' `claude` CLI. This is a per-deployment

--- a/scripts/deploy-mac-daemons.sh
+++ b/scripts/deploy-mac-daemons.sh
@@ -525,7 +525,15 @@ else
     # An all-typo mac.agents would otherwise select nothing and reconcile every
     # agent away — the exact "broken config tears the fleet down" failure the
     # gates are built to prevent. Refuse instead.
-    [ ${#SELECTED_AGENTS[@]} -gt 0 ] || die "mac.agents (openclaw.yml) matches no agent in openclaw_agents (${ALL_AGENT_IDS[*]}) — refusing to deploy nothing and reconcile everything away. Fix the list, or remove the key to deploy every agent."
+    #
+    # Guarded on mac_agents_configured so it fires ONLY for a real gate that
+    # matched nothing. Without the guard an empty openclaw_agents roster (no
+    # mac.agents anywhere) also lands here and dies blaming a key the user never
+    # set — and needlessly, since an unconfigured run gates nothing out and so
+    # has nothing to reconcile. An empty roster stays a no-op deploy, as before.
+    if mac_agents_configured && [ ${#SELECTED_AGENTS[@]} -eq 0 ]; then
+        die "mac.agents (openclaw.yml) matches no agent in openclaw_agents (${ALL_AGENT_IDS[*]}) — refusing to deploy nothing and reconcile everything away. Fix the list, or remove the key to deploy every agent."
+    fi
 fi
 
 # =============================================================================

--- a/scripts/deploy-mac-daemons.sh
+++ b/scripts/deploy-mac-daemons.sh
@@ -36,8 +36,11 @@
 # `launchctl ... system` calls). Idempotent and re-runnable.
 #
 # Usage:
-#   ./scripts/deploy-mac-daemons.sh                 # all agents, current account
-#   ./scripts/deploy-mac-daemons.sh main tl          # only these agents
+#   ./scripts/deploy-mac-daemons.sh                 # every agent mac.agents allows,
+#                                                   # current account; agents it
+#                                                   # excludes are reconciled away
+#   ./scripts/deploy-mac-daemons.sh main tl          # only these agents; overrides
+#                                                   # mac.agents and reconciles nothing
 #   ./scripts/deploy-mac-daemons.sh --status         # show daemon status
 #   ./scripts/deploy-mac-daemons.sh --uninstall      # remove this account's daemons
 #
@@ -87,7 +90,7 @@ sudo_prime() {
 }
 
 # --- Account index -> port-base offset ---------------------------------------
-# Derived from the mac_accounts order in openclaw.yml (position = index),
+# Derived from the mac.accounts order in openclaw.yml (position = index),
 # overridable with OPENCLAW_ACCOUNT_INDEX. See lib/mac-config.sh mac_account_index.
 # Only used to space qmd-http ports across accounts (irrelevant when qmd-http is
 # disabled). No hardcoded usernames — a fork configures its own accounts.
@@ -342,20 +345,22 @@ install_daemon() {
 
 # Reconcile a config-disabled service: if a daemon for this agent is installed or
 # loaded, bootout + rm it so `deploy` converges runtime to config. Only an
-# explicit mac_daemons.<svc>=false reaches here (mac_service_enabled treats
-# absent/empty/missing as enabled), so a missing config never triggers removal.
+# explicit mac.daemons.<svc>=false or an agent absent from a configured
+# mac.agents reaches here (both gates treat absent/empty/missing as enabled), so
+# a missing config never triggers removal.
+# $1 = svc  $2 = agent  $3 = reason shown in the log (default: disabled in config)
 reconcile_remove() {
-    local svc="$1" agent="$2" label plist
+    local svc="$1" agent="$2" reason="${3:-disabled in config}" label plist
     label="$(daemon_label "$svc" "$agent")"
     plist="$(daemon_plist "$svc" "$agent")"
     if [ "${DRY_RUN:-0}" = 1 ]; then
-        [ -f "$plist" ] && echo "  [dry-run] reconcile: would remove disabled ${label}"
+        [ -f "$plist" ] && echo "  [dry-run] reconcile: would remove ${label} (${reason})"
         return 0
     fi
     if [ -f "$plist" ] || sudo launchctl print "system/${label}" &>/dev/null; then
         sudo launchctl bootout "system/${label}" 2>/dev/null || true
         sudo rm -f "$plist"
-        echo "  reconciled (disabled in config): removed ${label}"
+        echo "  reconciled (${reason}): removed ${label}"
     fi
 }
 
@@ -396,10 +401,22 @@ show_status() {
         workspace="$(workspace_dir_for "$agent" "$WORKSPACES_DIR")"
         port="${PORT_MAP[$agent]}"
         echo ""
-        echo "--- ${agent} (qmd-http port ${port}) ---"
+        if mac_agent_enabled "$agent"; then
+            echo "--- ${agent} (qmd-http port ${port}) ---"
+        else
+            echo "--- ${agent} — gated out (not in mac.agents) ---"
+        fi
         for svc in git-sync obsidian-headless qmd-watch qmd-http; do
             label="$(daemon_label "$svc" "$agent")"
-            if ! mac_service_enabled "$svc"; then
+            if ! mac_agent_enabled "$agent"; then
+                # Surface drift: a gated-out agent that still has a daemon on
+                # disk means config and runtime disagree until a full deploy.
+                if [ -f "$(daemon_plist "$svc" "$agent")" ]; then
+                    printf "  %-18s installed — gated out, run a full deploy to reconcile\n" "$svc:"
+                else
+                    printf "  %-18s gated out (mac.agents)\n" "$svc:"
+                fi
+            elif ! mac_service_enabled "$svc"; then
                 printf "  %-18s disabled (config)\n" "$svc:"
             elif sudo launchctl print "system/${label}" &>/dev/null; then
                 printf "  %-18s loaded\n" "$svc:"
@@ -409,7 +426,7 @@ show_status() {
                 printf "  %-18s not deployed\n" "$svc:"
             fi
         done
-        if mac_service_enabled qmd-http && [ -f "$workspace/.qmd/index.sqlite" ]; then
+        if mac_agent_enabled "$agent" && mac_service_enabled qmd-http && [ -f "$workspace/.qmd/index.sqlite" ]; then
             if curl -sf "http://localhost:${port}/health" &>/dev/null; then
                 echo "  qmd-http health:   responding"
             else
@@ -467,6 +484,12 @@ case "${1:-}" in
 esac
 
 mapfile -t ALL_AGENT_IDS < <(get_agent_ids)
+
+# Agents this run should REMOVE daemons for rather than install. Populated only
+# on a full (unscoped) run: an explicit `deploy main` must touch main and nothing
+# else, exactly as a scoped run has always behaved.
+GATED_OUT_AGENTS=()
+
 SELECTED_AGENTS=()
 if [ $# -gt 0 ]; then
     for arg in "$@"; do
@@ -480,7 +503,29 @@ if [ $# -gt 0 ]; then
         $found || die "Unknown agent '$arg'. Available: ${ALL_AGENT_IDS[*]}"
     done
 else
-    SELECTED_AGENTS=("${ALL_AGENT_IDS[@]}")
+    # A mac.agents entry matching no real agent is almost certainly a typo, and
+    # its only visible effect would be an agent quietly not deploying — say so.
+    while IFS= read -r listed; do
+        [ -n "$listed" ] || continue
+        found=false
+        for id in "${ALL_AGENT_IDS[@]}"; do
+            [ "$id" = "$listed" ] && { found=true; break; }
+        done
+        $found || warn "mac.agents lists '${listed}', which is not in openclaw_agents (${ALL_AGENT_IDS[*]}) — ignoring it."
+    done < <(mac_agents_listed)
+
+    for id in "${ALL_AGENT_IDS[@]}"; do
+        if mac_agent_enabled "$id"; then
+            SELECTED_AGENTS+=("$id")
+        else
+            GATED_OUT_AGENTS+=("$id")
+        fi
+    done
+
+    # An all-typo mac.agents would otherwise select nothing and reconcile every
+    # agent away — the exact "broken config tears the fleet down" failure the
+    # gates are built to prevent. Refuse instead.
+    [ ${#SELECTED_AGENTS[@]} -gt 0 ] || die "mac.agents (openclaw.yml) matches no agent in openclaw_agents (${ALL_AGENT_IDS[*]}) — refusing to deploy nothing and reconcile everything away. Fix the list, or remove the key to deploy every agent."
 fi
 
 # =============================================================================
@@ -511,6 +556,7 @@ echo "=========================================="
 echo "  openclaw system-daemon deploy"
 echo "  account:  ${ACCOUNT} (index ${ACCOUNT_INDEX})"
 echo "  agents:   ${SELECTED_AGENTS[*]}"
+[ ${#GATED_OUT_AGENTS[@]} -eq 0 ] || echo "  gated out: ${GATED_OUT_AGENTS[*]} (mac.agents)"
 echo "  ob bin:   ${OB_BIN:-<not found — obsidian skipped>}"
 echo "=========================================="
 
@@ -609,6 +655,22 @@ for agent in "${SELECTED_AGENTS[@]}"; do
         teardown_old_launchagent "$old_plist"
     done < <(old_launchagent_plists "$agent")
 done
+
+# =============================================================================
+# Reconcile agents gated out by mac.agents
+# =============================================================================
+# Same convergence contract as a config-disabled service: a full run makes
+# runtime match config. Unreachable on a scoped run and on an unconfigured one
+# (GATED_OUT_AGENTS is empty in both cases), so neither can remove anything.
+if [ ${#GATED_OUT_AGENTS[@]} -gt 0 ]; then
+    echo ""
+    log "agents gated out by mac.agents: ${GATED_OUT_AGENTS[*]}"
+    for agent in "${GATED_OUT_AGENTS[@]}"; do
+        for svc in git-sync obsidian-headless qmd-watch qmd-http; do
+            reconcile_remove "$svc" "$agent" "not in mac.agents"
+        done
+    done
+fi
 
 echo ""
 echo "=========================================="

--- a/scripts/lib/mac-config.sh
+++ b/scripts/lib/mac-config.sh
@@ -10,10 +10,12 @@
 #      — or change the defaults here. Defaults match the upstream author's macOS
 #      fleet, so an unconfigured run reproduces that setup out of the box.
 #
-#   2. Per-deployment POLICY — which daemons run, and account order for qmd-http
-#      port bases — lives in ansible/group_vars/openclaw.yml (mac_daemons /
-#      mac_accounts; see openclaw.yml.example). That file is gitignored, so your
-#      choices never propagate to the shared script.
+#   2. Per-deployment POLICY — which agents get daemons, which daemons run, and
+#      account order for qmd-http port bases — lives in the single `mac:` block
+#      of ansible/group_vars/openclaw.yml (see openclaw.yml.example). That file
+#      is gitignored, so your choices never propagate to the shared script.
+#      If you are not on a Mac, that block is the only thing in the shared SoT
+#      you can ignore wholesale.
 #
 # Sourced, not executed. The openclaw.yml readers require yq + jq (already
 # required by lib/agents.sh, which every caller also sources).
@@ -67,17 +69,59 @@ resolve_ob_bin() {
 _MAC_CFG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _MAC_OPENCLAW_YML="$_MAC_CFG_DIR/../../ansible/group_vars/openclaw.yml"
 
-# Disabled-service set, parsed ONCE at source time (a per-call yq|jq would fork
-# 36+ times across a deploy). Only keys explicitly set to false land here, so
-# absent key / null / empty / missing file ⇒ enabled — fail-safe: a broken or
-# empty config can never silently tear the fleet down. Selecting `== false`
-# explicitly also sidesteps jq's `//`, which treats a literal false as empty.
-declare -A _MAC_SVC_DISABLED=()
+# All Mac policy is read ONCE at source time into a single JSON blob (a per-call
+# yq|jq would fork 36+ times across a deploy). One yq invocation resolves the
+# nested `mac:` block and falls back to the pre-nesting flat keys, so an existing
+# fork that set mac_daemons/mac_accounts keeps working untouched.
+#
+# The default blob (no config file) is the permissive one: no services disabled,
+# no agent gate, no account order. Every read below therefore degrades to
+# "everything enabled" — fail-safe: a broken, empty, or missing config can never
+# silently tear the fleet down.
+_MAC_POLICY_DEFAULT='{"agents":null,"daemons":{},"accounts":[],"legacy":false}'
+_MAC_POLICY_JSON="$_MAC_POLICY_DEFAULT"
 if [ -f "$_MAC_OPENCLAW_YML" ]; then
-    while IFS= read -r _svc; do
-        [ -n "$_svc" ] && _MAC_SVC_DISABLED["$_svc"]=1
-    done < <(yq -o json '.mac_daemons // {}' "$_MAC_OPENCLAW_YML" 2>/dev/null \
-        | jq -r 'to_entries[] | select(.value == false) | .key' 2>/dev/null || true)
+    # `legacy` is true only when the flat keys are what is actually supplying
+    # policy (no `mac:` block present) — that is the one case worth warning about.
+    #
+    # ORDER IS LOAD-BEARING: `legacy` MUST come first. Traversing `.mac.agents`
+    # auto-vivifies `.mac` in mikefarah yq (v4), so any later `has("mac")` or
+    # `.mac == null` sees a node the traversal itself created and the flat-key
+    # warning silently never fires. Verified on yq v4.53.3.
+    _MAC_POLICY_JSON="$(yq -o json -I 0 '{
+        "legacy":   ((has("mac") | not) and (has("mac_daemons") or has("mac_accounts"))),
+        "agents":   (.mac.agents   // null),
+        "daemons":  (.mac.daemons  // .mac_daemons  // {}),
+        "accounts": (.mac.accounts // .mac_accounts // [])
+    }' "$_MAC_OPENCLAW_YML" 2>/dev/null || echo "$_MAC_POLICY_DEFAULT")"
+    [ -n "$_MAC_POLICY_JSON" ] || _MAC_POLICY_JSON="$_MAC_POLICY_DEFAULT"
+fi
+
+# Disabled-service set. Only keys explicitly set to false land here, so absent /
+# null / empty ⇒ enabled. Selecting `== false` explicitly also sidesteps jq's
+# `//`, which treats a literal false as empty.
+declare -A _MAC_SVC_DISABLED=()
+while IFS= read -r _svc; do
+    [ -n "$_svc" ] && _MAC_SVC_DISABLED["$_svc"]=1
+done < <(printf '%s' "$_MAC_POLICY_JSON" \
+    | jq -r '.daemons | to_entries[] | select(.value == false) | .key' 2>/dev/null || true)
+
+# Per-agent gate. `_MAC_AGENTS_CONFIGURED` flips only when at least one agent is
+# listed, so both an absent `mac.agents` and an explicitly empty one mean "every
+# agent" — the same fail-safe as the service gate, and deliberately unlike the
+# VPS-side `obsidian_headless_agents: []` (which means "nobody"). The asymmetry
+# is intentional: that key opts INTO an optional feature, whereas this one
+# RESTRICTS an already-running set, so the safe default is the permissive one.
+declare -A _MAC_AGENT_ALLOWED=()
+_MAC_AGENTS_CONFIGURED=0
+while IFS= read -r _agent; do
+    [ -n "$_agent" ] || continue
+    _MAC_AGENT_ALLOWED["$_agent"]=1
+    _MAC_AGENTS_CONFIGURED=1
+done < <(printf '%s' "$_MAC_POLICY_JSON" | jq -r '(.agents // [])[]' 2>/dev/null || true)
+
+if [ "$(printf '%s' "$_MAC_POLICY_JSON" | jq -r '.legacy' 2>/dev/null)" = "true" ]; then
+    echo "NOTE: openclaw.yml still uses the flat mac_daemons/mac_accounts keys. Nest them under a single 'mac:' block (mac.daemons / mac.accounts / mac.agents) — see openclaw.yml.example. The flat keys still work." >&2
 fi
 
 # Is a Mac daemon service enabled for deployment? Pure lookup — no subprocess.
@@ -86,8 +130,27 @@ mac_service_enabled() {
     [ -z "${_MAC_SVC_DISABLED[$1]:-}" ]
 }
 
+# Is the per-agent gate configured at all? The deployer consults this before
+# reconciling gated-out agents, so an unconfigured run never removes anything.
+mac_agents_configured() {
+    [ "$_MAC_AGENTS_CONFIGURED" = 1 ]
+}
+
+# Does this agent get Mac daemons? Unconfigured ⇒ every agent. $1 = agent id.
+mac_agent_enabled() {
+    mac_agents_configured || return 0
+    [ -n "${_MAC_AGENT_ALLOWED[$1]:-}" ]
+}
+
+# Agent ids listed in mac.agents, one per line — lets callers that know the real
+# roster flag a typo'd entry that would otherwise gate an agent out in silence.
+mac_agents_listed() {
+    mac_agents_configured || return 0
+    printf '%s\n' "${!_MAC_AGENT_ALLOWED[@]}"
+}
+
 # Port-base index for an account. Precedence: OPENCLAW_ACCOUNT_INDEX env >
-# position in mac_accounts > 0 (with a warning). Never hard-fails, so a
+# position in mac.accounts > 0 (with a warning). Never hard-fails, so a
 # single-account fork works with no config. $1 = account name.
 mac_account_index() {
     local account="$1" idx
@@ -99,13 +162,11 @@ mac_account_index() {
             *) echo "$OPENCLAW_ACCOUNT_INDEX"; return ;;
         esac
     fi
-    if [ -f "$_MAC_OPENCLAW_YML" ]; then
-        idx="$(yq -o json '.mac_accounts // []' "$_MAC_OPENCLAW_YML" 2>/dev/null \
-            | jq -r --arg a "$account" 'index($a) // ""' 2>/dev/null || echo "")"
-        if [ -n "$idx" ] && [ "$idx" != "null" ]; then
-            echo "$idx"; return
-        fi
+    idx="$(printf '%s' "$_MAC_POLICY_JSON" \
+        | jq -r --arg a "$account" '.accounts | index($a) // ""' 2>/dev/null || echo "")"
+    if [ -n "$idx" ] && [ "$idx" != "null" ]; then
+        echo "$idx"; return
     fi
-    echo "WARNING: account '$account' not found in mac_accounts (openclaw.yml) and OPENCLAW_ACCOUNT_INDEX unset — using port-base index 0. Set OPENCLAW_ACCOUNT_INDEX to avoid cross-account qmd-http port collisions." >&2
+    echo "WARNING: account '$account' not found in mac.accounts (openclaw.yml) and OPENCLAW_ACCOUNT_INDEX unset — using port-base index 0. Set OPENCLAW_ACCOUNT_INDEX to avoid cross-account qmd-http port collisions." >&2
     echo 0
 }

--- a/scripts/lib/mac-config.sh
+++ b/scripts/lib/mac-config.sh
@@ -112,13 +112,20 @@ done < <(printf '%s' "$_MAC_POLICY_JSON" \
 # VPS-side `obsidian_headless_agents: []` (which means "nobody"). The asymmetry
 # is intentional: that key opts INTO an optional feature, whereas this one
 # RESTRICTS an already-running set, so the safe default is the permissive one.
+#
+# The `type == "array"` guard makes a mis-shaped key (a map, a bare scalar) fail
+# OPEN rather than gate on whatever jq's `.[]` happens to yield — iterating a map
+# walks its VALUES, so `agents: {a: main}` would otherwise silently restrict to
+# `main`. Contents are deliberately NOT filtered: a real list holding wrong values
+# still reaches the roster check, which refuses loudly instead of ignoring it.
 declare -A _MAC_AGENT_ALLOWED=()
 _MAC_AGENTS_CONFIGURED=0
 while IFS= read -r _agent; do
     [ -n "$_agent" ] || continue
     _MAC_AGENT_ALLOWED["$_agent"]=1
     _MAC_AGENTS_CONFIGURED=1
-done < <(printf '%s' "$_MAC_POLICY_JSON" | jq -r '(.agents // [])[]' 2>/dev/null || true)
+done < <(printf '%s' "$_MAC_POLICY_JSON" \
+    | jq -r 'if (.agents | type) == "array" then .agents[] else empty end' 2>/dev/null || true)
 
 if [ "$(printf '%s' "$_MAC_POLICY_JSON" | jq -r '.legacy' 2>/dev/null)" = "true" ]; then
     echo "NOTE: openclaw.yml still uses the flat mac_daemons/mac_accounts keys. Nest them under a single 'mac:' block (mac.daemons / mac.accounts / mac.agents) — see openclaw.yml.example. The flat keys still work." >&2


### PR DESCRIPTION
## Why

The Mac deployer ran all four per-agent services for **every** agent in `openclaw_agents`, with no way to run a subset locally. Dropping agents from `openclaw_agents` isn't an option — that key is the fleet-wide roster driving the VPS agents, telegram, whatsapp and plugins — so a Mac that should carry only a few agents had to keep deploying all of them, at ~3 resident processes per agent per account.

## What

**`mac.agents`** — a per-agent gate for the Mac only. The VPS keeps running every agent.

The existing Mac keys are nested under one `mac:` block at the same time. Most forkers run the Linux/systemd VPS and never a Mac; nesting keeps the shared SoT's Mac surface to a single skippable block that *cannot widen* as knobs are added, and takes it from two top-level keys to one.

```yaml
mac:
  agents:   [main, tl, manon]   # new — absent/empty means every agent
  daemons:  {qmd-http: false}
  accounts: [spannagel, tl]
```

## Fork safety

Absent or empty `mac.agents` means **every agent**, so a missing or broken config can never tear a fleet down — the same contract `mac_daemons` already has.

This deliberately **inverts** `obsidian_headless_agents` (`[]` = nobody). That key opts *into* an optional feature; this one *restricts* an already-running set, so the safe default flips. Called out in the example config.

The flat `mac_daemons` / `mac_accounts` keys still work and now print a migration note.

## Safety rails

- **Refuses to run** when `mac.agents` matches no real agent, rather than selecting nothing and reconciling every agent away — the exact "broken config wipes the fleet" failure the gates exist to prevent.
- Unknown entries alongside valid ones **warn** rather than silently gating an agent out.
- An explicit `deploy-mac-daemons.sh <agent>` overrides the gate and reconciles nothing, preserving scoped-run behaviour.
- `--status` gains a gated-out state that flags config/runtime drift.

## Verification

A dry-run harness covering 7 cases, all passing:

| Case | Result |
|---|---|
| No mac config, this rev vs previous | **plists byte-identical** (6 files) |
| Flat keys vs previous rev | **byte-identical**, migration note shown |
| Nested block vs flat keys | **byte-identical**, no note |
| `mac.agents: [main, tl]` | only main + tl emitted; rest reconciled |
| All-typo list | refuses, exit 1, emits nothing |
| Typo beside a valid agent | warns, still deploys |
| Explicit CLI arg | deploys a gated-out agent, reconciles nothing |

Reconcile was additionally verified against **real** `/Library/LaunchDaemons` state in `--dry-run`: it identified exactly the three existing plists of a gated-out agent and nothing else.

`shellcheck -S error` clean on `scripts/*.sh` and `scripts/lib/*.sh`.

## Note for reviewers

Ordering inside the `yq` map is load-bearing and commented. Traversing `.mac.agents` **auto-vivifies** `.mac` in yq v4, so `legacy` must be computed first — otherwise `has("mac")` sees a node the traversal itself created and the flat-key migration note silently never fires. Caught by the harness, not by reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)