### PR TITLE
mac: move the ob Node pin to 26 for obsidian-headless 0.0.13

### DIFF
--- a/scripts/deploy-mac-daemons.sh
+++ b/scripts/deploy-mac-daemons.sh
@@ -119,8 +119,9 @@ old_launchagent_plists() {
 # git-sync: no node needed (the sync script only shells out to git).
 GIT_SYNC_PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 # obsidian-headless: pin Node via OB_NODE_BIN (lib/mac-config.sh). ob's native
-# better-sqlite3 is ABI-locked to that Node major, so the default Node (which may
-# be 26) would break it; resolve_node_bin_dir() would hand back the wrong one.
+# better-sqlite3 is ABI-locked to one Node major, and WHICH major depends on the
+# ob version — so the machine default is wrong in both directions, not just when
+# it is too new. lib/mac-config.sh owns the mapping; keep them in step.
 OBSIDIAN_PATH="${OB_NODE_BIN}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 # qmd-watch + qmd-http: bun first, then mise shims (default Node 26 is fine for
 # qmd — its better-sqlite3 12.10.0 has a Node-26 prebuilt).

--- a/scripts/lib/mac-config.sh
+++ b/scripts/lib/mac-config.sh
@@ -32,11 +32,26 @@
 # Daemon stdout/stderr logs.
 : "${LOG_DIR:=$HOME/Library/Logs/openclaw}"
 
-# obsidian-headless's native better-sqlite3 is ABI-locked to a Node major (the
-# 12.6.2 build has no Node-26 prebuild and won't compile on 26), so ob must run
-# under a pinned Node regardless of the default. OB_NODE_BIN derives from the
-# version via the mise install path; set OB_NODE_BIN directly if you don't use mise.
-: "${OB_NODE_VERSION:=23.11.0}"
+# obsidian-headless's native better-sqlite3 is ABI-locked to a Node major, so ob
+# runs under a pinned Node regardless of the machine default. OB_NODE_BIN derives
+# from the version via the mise install path; set OB_NODE_BIN directly if you
+# don't use mise. deploy-mac-daemons.sh SKIPS obsidian-headless when this
+# directory is missing — better a missing service than a crash-looping one.
+#
+# The pin tracks obsidian-headless's better-sqlite3, and moved with 0.0.13:
+#   <= 0.0.12  better-sqlite3 12.6.2   -> Node 23 (no Node-26 prebuild)
+#   >= 0.0.13  better-sqlite3 12.11.1  -> Node 26 (no Node-23 prebuild)
+# The two are mutually exclusive, so upgrading ob and bumping this must happen
+# together. Still on <= 0.0.12? Set OB_NODE_VERSION=23.11.0.
+#
+# GOTCHA when installing ob with pnpm 10+: build scripts are blocked by default,
+# so better-sqlite3 ships NO compiled binary and ob dies at require() with
+# MODULE_NOT_FOUND for every ABI. There is no prebuild for Node 26 either — it is
+# compiled locally — so the build must actually run:
+#   pnpm add -g --allow-build=better-sqlite3 obsidian-headless@<version>
+# (`pnpm approve-builds` does not work for global installs.) Verify with
+# `ob --version` plus a real sync; a bare `--version` does not load the addon.
+: "${OB_NODE_VERSION:=26.3.0}"
 : "${OB_NODE_BIN:=$HOME/.local/share/mise/installs/node/${OB_NODE_VERSION}/bin}"
 
 # GitHub org owning the openclaw-workspace[-<id>] repos (setup-mac-workspaces.sh).


### PR DESCRIPTION
## Why

`obsidian-headless` 0.0.13 bumped `better-sqlite3` 12.6.2 → 12.11.1, which **flips** the ABI lock rather than removing it:

| ob version | better-sqlite3 | Works on |
|---|---|---|
| ≤ 0.0.12 | 12.6.2 | Node 23 (no Node-26 prebuild) |
| ≥ 0.0.13 | 12.11.1 | Node 26 — **Node 23 fails** (no Node-23 prebuild) |

They're mutually exclusive, so `OB_NODE_VERSION=23.11.0` is now actively wrong for a current `ob`.

## How it showed up

Both failure modes were observed live, on two machines, from the same upgrade:

- **The machine that *has* mise 23.11.0**: after upgrading ob, every obsidian daemon crash-looped — `MODULE_NOT_FOUND` ending at `lib/binding/node-v131-darwin-arm64` (ABI 131 = Node 23).
- **The machine that *lacks* it**: unaffected at runtime, because the missing pin directory made `deploy-mac-daemons.sh` **silently skip obsidian-headless for every agent** (3/3). A latent outage waiting for the next deploy.

## Changes

- `OB_NODE_VERSION` default 23.11.0 → **26.3.0**, with the version→ABI mapping documented next to it so the two get bumped together. Forks on ≤ 0.0.12 set `OB_NODE_VERSION=23.11.0`; still env-overridable, so no forced migration.
- Document the **pnpm 10+ gotcha**, which cost the most time to find: build scripts are blocked by default, so `better-sqlite3` installs with *no compiled binary at all* and `ob` dies at `require()` for every ABI — not just the wrong one. There's no Node-26 prebuild either (it compiles locally), so the build has to actually run:
  ```
  pnpm add -g --allow-build=better-sqlite3 obsidian-headless@<version>
  ```
  `pnpm approve-builds` is rejected outright for global installs. And `ob --version` does **not** load the addon, so it's not a valid health check — use a real sync.
- Fix the `OBSIDIAN_PATH` comment in the deployer, which claimed only a *too-new* default Node breaks ob. It breaks in both directions.

## Verification

| | merged `main` | this branch |
|---|---|---|
| `obsidian-headless skipped … pinned Node` | **3** | **0** |
| obsidian plists emitted | 0 | 3 |

`shellcheck -S error` clean on `scripts/*.sh` and `scripts/lib/*.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)